### PR TITLE
Outward shared

### DIFF
--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Config/ConfigManagerService.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Config/ConfigManagerService.cs
@@ -23,8 +23,9 @@ namespace ModifAmorphic.Outward.Config
         {
             var buildSettingList = _reflectedConfigManager.GetType().GetMethod("BuildSettingList");
 #if DEBUG
-            (new Logger(LogLevel.Debug, DebugLoggerInfo.ModName)).LogDebug(
-                $"[{DebugLoggerInfo.ModName}] - Refreshing ConfigurationManager " +
+            var _logger = LoggerFactory.ConfigureLogger(DebugLoggerInfo.ModId, DebugLoggerInfo.ModName, DebugLoggerInfo.DebugLogLevel);
+            _logger.LogDebug(
+                $"Refreshing ConfigurationManager " +
                 $"Reflected ConfigurationManager found? {_reflectedConfigManager != null}. " +
                 $"BuildSettingList method found? {buildSettingList != null}.");
 #endif

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Config/ConfigSettingsService.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Config/ConfigSettingsService.cs
@@ -11,7 +11,7 @@ namespace ModifAmorphic.Outward.Config
     public class ConfigSettingsService
     {
 #if DEBUG
-        private readonly Logger _logger = new Logger(LogLevel.Trace, DebugLoggerInfo.ModName);
+        private readonly IModifLogger _logger = LoggerFactory.ConfigureLogger(DebugLoggerInfo.ModId, DebugLoggerInfo.ModName, DebugLoggerInfo.DebugLogLevel);
 #endif
         public ConfigFile Config { get; }
         private readonly ConfigManagerService _configManagerService;
@@ -20,9 +20,7 @@ namespace ModifAmorphic.Outward.Config
         {
             (Config, _configManagerService) = (unityPlugin.Config, new ConfigManagerService(unityPlugin));
 #if DEBUG
-            _logger.LogDebug($"[{DebugLoggerInfo.ModName}] - {nameof(ConfigSettingsService)}: Bound to ConfigFile {Config.ConfigFilePath}."
-                
-            );
+            _logger.LogDebug($"{nameof(ConfigSettingsService)}: Bound to ConfigFile {Config.ConfigFilePath}.");
 #endif
         }
 
@@ -42,7 +40,7 @@ namespace ModifAmorphic.Outward.Config
             configEntry.SettingChanged += (object sender, EventArgs e) => configSetting.Value = configSetting.BoundConfigEntry.Value;
             configSetting.Value = configSetting.BoundConfigEntry.Value;
 #if DEBUG
-            _logger.LogDebug($"[{DebugLoggerInfo.ModName}] - Bound ConfigSetting: {configSetting.Name} to ConfigEntry {configEntry.Definition.Key} with value {configEntry.Value}");
+            _logger.LogDebug($"Bound ConfigSetting: {configSetting.Name} to ConfigEntry {configEntry.Definition.Key} with value {configEntry.Value}");
 #endif
             configSetting.SuppressValueChangedEvents = bindRaisesChangeEvent;
             return configSetting;
@@ -96,7 +94,7 @@ namespace ModifAmorphic.Outward.Config
             //type doesn't really matter at all unless you try to get or bind to it again as a different type.
             //They're all strings in the end...
 #if DEBUG
-            _logger.LogDebug($"[{DebugLoggerInfo.ModName}] {nameof(PeekConfigEntry)} - Peeking for ConfigEntry<string> {configSetting.Name} in section {configSetting.ToConfigDefinition().Section}." +
+            _logger.LogDebug($"{nameof(PeekConfigEntry)} - Peeking for ConfigEntry<string> {configSetting.Name} in section {configSetting.ToConfigDefinition().Section}." +
                 $" Using DefaultValue of '{defaultValue}'.");
 #endif
 
@@ -105,7 +103,7 @@ namespace ModifAmorphic.Outward.Config
                 tempEntry = Config.Bind(configSetting.ToConfigDefinition(), defaultValue, configSetting.ToConfigDescription());
             }
 #if DEBUG
-            _logger.LogDebug($"[{DebugLoggerInfo.ModName}] {nameof(PeekConfigEntry)} - Got temporary ConfigEntry<string> {tempEntry.Definition.Key} with value of '{tempEntry.Value}'");
+            _logger.LogDebug($"{nameof(PeekConfigEntry)} - Got temporary ConfigEntry<string> {tempEntry.Definition.Key} with value of '{tempEntry.Value}'");
 #endif
             //Now that we have it, remove it so ConfigFile doesn't save this temporary entry
             Config.Clear();
@@ -120,7 +118,7 @@ namespace ModifAmorphic.Outward.Config
             {
                 peekedEntry = Config.Bind(configSetting.ToConfigDefinition(), configSetting.DefaultValue, configSetting.ToConfigDescription());
 #if DEBUG
-                _logger.LogDebug($"[{DebugLoggerInfo.ModName}] {nameof(PeekConfigEntry)} - Found {configSetting.Name} in section {configSetting.ToConfigDefinition().Section}. Getting typed ConfigEntry<{typeof(T).Name}>.");
+                _logger.LogDebug($"{nameof(PeekConfigEntry)} - Found {configSetting.Name} in section {configSetting.ToConfigDefinition().Section}. Getting typed ConfigEntry<{typeof(T).Name}>.");
 #endif
                 Config.Clear();
                 Config.Reload();

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Config/Extensions/ConfigSettingExtensions.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Config/Extensions/ConfigSettingExtensions.cs
@@ -6,6 +6,9 @@ namespace ModifAmorphic.Outward.Config.Extensions
 {
     public static class ConfigSettingExtensions
     {
+#if DEBUG
+        private static readonly Logging.IModifLogger _logger = Logging.LoggerFactory.ConfigureLogger(DebugLoggerInfo.ModId, DebugLoggerInfo.ModName, DebugLoggerInfo.DebugLogLevel);
+#endif
         public static ConfigDefinition ToConfigDefinition<T>(this ConfigSetting<T> configSetting)
         {
             return new ConfigDefinition(
@@ -32,7 +35,7 @@ namespace ModifAmorphic.Outward.Config.Extensions
             configSetting.IsVisible = false;
             configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes().Browsable = configSetting.IsVisible;
 #if DEBUG
-            UnityEngine.Debug.Log($"[{DebugLoggerInfo.ModName}] - Hid ConfigSetting {configSetting.Name}. " +
+            _logger.LogDebug($"Hid ConfigSetting {configSetting.Name}. " +
                 $"IsVisible = {configSetting.IsVisible}. " +
                 $"Browsable = {configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes().Browsable}.");
 #endif
@@ -44,7 +47,7 @@ namespace ModifAmorphic.Outward.Config.Extensions
             configSetting.IsVisible = true;
             configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes().Browsable = configSetting.IsVisible;
 #if DEBUG
-            UnityEngine.Debug.Log($"[{DebugLoggerInfo.ModName}] - Showed ConfigSetting {configSetting.Name}. " +
+            _logger.LogDebug($"Showed ConfigSetting {configSetting.Name}. " +
                 $"IsVisible = {configSetting.IsVisible}. " +
                 $"Browsable = {configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes().Browsable}.");
 #endif

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Config/Models/ConfigSetting.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Config/Models/ConfigSetting.cs
@@ -40,7 +40,8 @@ namespace ModifAmorphic.Outward.Config.Models
             if (!SuppressValueChangedEvents)
             {
 #if DEBUG
-                UnityEngine.Debug.Log($"[{DebugLoggerInfo.ModName}] - ConfigSetting: {this.Name}. Triggering {nameof(ValueChanged)} Event. " +
+                var logger = Logging.LoggerFactory.ConfigureLogger(DebugLoggerInfo.ModId, DebugLoggerInfo.ModName, DebugLoggerInfo.DebugLogLevel);
+                logger.LogTrace($"ConfigSetting: {this.Name}. Triggering {nameof(ValueChanged)} Event. " +
                     $"oldValue: {oldValue}. newvalue: {newValue} " +
                     $"{nameof(ValueChanged)} null? {ValueChanged == null}. " +
                     $"{nameof(SuppressValueChangedEvents)}? {SuppressValueChangedEvents}");

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/DebugLoggerInfo.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/DebugLoggerInfo.cs
@@ -1,9 +1,13 @@
 ﻿#if DEBUG
+using ModifAmorphic.Outward.Logging;
+
 namespace ModifAmorphic.Outward
 {
     internal static class DebugLoggerInfo
     {
-        public const string ModName = "ModifAmorphic Shared Library";
+        public const string ModId = "modifamorphic.outward.shared";
+        public const string ModName = "ModifAmorphic";
+        public const LogLevel DebugLogLevel = LogLevel.Trace;
     }
 }
 #endif

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Events/LoggerEvents.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Events/LoggerEvents.cs
@@ -5,10 +5,16 @@ namespace ModifAmorphic.Outward.Events
 {
     internal static class LoggerEvents
     {
-        public static event EventHandler<Func<IModifLogger>> LoggerReady;
-        public static void RaiseLoggerReady(object sender, Func<IModifLogger> loggerFactory)
+        public static event Action<(string ModId, IModifLogger Logger)> LoggerCreated;
+        public static void RaiseLoggerCreated(string modId, IModifLogger logger)
         {
-            LoggerReady?.Invoke(sender, loggerFactory);
+            LoggerCreated?.Invoke((modId, logger));
+        }
+
+        public static event Action<(string ModId, IModifLogger Logger)> LoggerConfigured;
+        public static void RaiseLoggerConfigured(string modId, IModifLogger logger)
+        {
+            LoggerConfigured?.Invoke((modId, logger));
         }
     }
 }

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Extensions/LoggingExtensions.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Extensions/LoggingExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ModifAmorphic.Outward.Extensions
+{
+    public static class LoggingExtensions
+    {
+        public static BepInEx.Logging.LogLevel ToBepLogLevel(this Logging.LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case Logging.LogLevel.Error:
+                    return BepInEx.Logging.LogLevel.Error;
+                case Logging.LogLevel.Warning:
+                    return BepInEx.Logging.LogLevel.Warning;
+                case Logging.LogLevel.Info:
+                    return BepInEx.Logging.LogLevel.Info;
+                case Logging.LogLevel.Debug:
+                    return BepInEx.Logging.LogLevel.Debug;
+                case Logging.LogLevel.Trace:
+                    return BepInEx.Logging.LogLevel.Debug;
+                default:
+                    return BepInEx.Logging.LogLevel.Info;
+            }
+            
+        }
+    }
+}

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Internal/ManifestFiles.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Internal/ManifestFiles.cs
@@ -12,16 +12,26 @@ namespace ModifAmorphic.Outward.Internal
     {
         public static void RemoveOtherVersions(IModifLogger logger)
         {
+            //This Shared Outward Assembly. May be different from mod directory if multiple
+            //mods with the same version of this assembly are installed.
             var thisAssembly = Assembly.GetExecutingAssembly();
-            var assemblyDir = Path.GetDirectoryName(thisAssembly.Location);
+            var thisFilename = Path.GetFileName(thisAssembly.Location);
 
-            var fileNames = Directory.GetFiles(assemblyDir, "ModifAmorphic.Outward.v*_*_*.dll").ToList();
-            if (File.Exists(Path.Combine(assemblyDir, "ModifAmorphic.Outward.dll")))
-                fileNames.Add(Path.Combine(assemblyDir, "ModifAmorphic.Outward.dll"));
+            //The mod assembly calling this method
+            var callingAssembly = Assembly.GetCallingAssembly();
+            var callingDir = Path.GetDirectoryName(callingAssembly.Location);
 
-            foreach (var fileName in fileNames)
+            //Get all of the potential Outward Shared assemblies in the calling mods folder.
+            var filePaths = Directory.GetFiles(callingDir, "ModifAmorphic.Outward.v*_*_*.dll").ToList();
+
+            //Check for original shared assembly name prior to versioning.
+            if (File.Exists(Path.Combine(callingDir, "ModifAmorphic.Outward.dll")))
+                filePaths.Add(Path.Combine(callingDir, "ModifAmorphic.Outward.dll"));
+            logger.LogDebug($"{nameof(ManifestFiles)}::{nameof(RemoveOtherVersions)}: Mod is using Outward.Shared assembly loaded from '{thisAssembly.Location}'." +
+                $" Calling mod directory is '{callingDir}'.");
+            foreach (var fileName in filePaths)
             {
-                if (thisAssembly.Location != fileName)
+                if (thisFilename != Path.GetFileName(fileName))
                 {
                     logger.LogDebug($"{nameof(ManifestFiles)}::{nameof(RemoveOtherVersions)}: Deleting Assembly file '{fileName}'");
                     File.Delete(fileName);

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/BepInExLogger.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/BepInExLogger.cs
@@ -1,0 +1,56 @@
+﻿using BepInEx.Logging;
+using ModifAmorphic.Outward.Extensions;
+using System;
+
+namespace ModifAmorphic.Outward.Logging
+{
+    public class BepInExLogger : IModifLogger
+    {
+        public LogLevel LogLevel { get; set; }
+        public string LoggerName { get; }
+
+        private readonly ManualLogSource _bepInExLogger;
+        public BepInExLogger(LogLevel logLevel, string loggerName)
+        {
+            this.LogLevel = logLevel;
+            this.LoggerName = loggerName;
+            _bepInExLogger = BepInEx.Logging.Logger.CreateLogSource(loggerName);
+        }
+        public void Log(LogLevel logLevel, string message)
+        {
+            //string logMsg = $"[{this.LoggerName}][{Enum.GetName(typeof(LogLevel), logLevel)}] - {message}";
+            if (logLevel <= this.LogLevel)
+            {
+                _bepInExLogger.Log(logLevel.ToBepLogLevel(), message);
+            }
+        }
+        public void LogTrace(string message)
+        {
+            Log(LogLevel.Trace, message);
+        }
+        public void LogDebug(string message)
+        {
+            Log(LogLevel.Debug, message);
+        }
+        public void LogInfo(string message)
+        {
+            Log(LogLevel.Info, message);
+        }
+        public void LogWarning(string message)
+        {
+            Log(LogLevel.Warning, message);
+        }
+        public void LogError(string message)
+        {
+            Log(LogLevel.Error, message);
+        }
+        public void LogException(Exception ex)
+        {
+            Log(LogLevel.Error, ex.ToString());
+        }
+        public void LogException(string message, Exception ex)
+        {
+            Log(LogLevel.Error, message + " | Exception: " + ex.ToString());
+        }
+    }
+}

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/Logger.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/Logger.cs
@@ -4,7 +4,7 @@ namespace ModifAmorphic.Outward.Logging
 {
     public class Logger : IModifLogger
     {
-        public LogLevel LogLevel { get; }
+        public LogLevel LogLevel { get; set; }
         public string LoggerName { get; }
         public Logger(LogLevel logLevel, string loggerName)
         {

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/LoggerFactory.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/LoggerFactory.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using ModifAmorphic.Outward.Events;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
 
@@ -6,15 +8,39 @@ namespace ModifAmorphic.Outward.Logging
 {
     public static class LoggerFactory
     {
-        private static IModifLogger _logger;
-        private static readonly IModifLogger _defaultLogger = new Logger(LogLevel.Warning, "ModifAmorphic-Outward");
-        public static void ConfigureLogging(string loggerName, LogLevel logLevel)
+        //readonly static ConcurrentDictionary<string, Func<IModifLogger>> _loggerFactories = new ConcurrentDictionary<string, Func<IModifLogger>>();
+        readonly static ConcurrentDictionary<string, IModifLogger> _loggers = new ConcurrentDictionary<string, IModifLogger>();
+        readonly static IModifLogger _nullLogger = new NullLogger();
+
+        public static IModifLogger ConfigureLogger(string modId, string loggerName, LogLevel logLevel)
         {
-            _logger = new Logger(logLevel, loggerName);
+#if DEBUG
+            (new Logger(LogLevel.Debug, DebugLoggerInfo.ModName)).LogDebug(
+                $"{nameof(LoggerFactory)}::{nameof(ConfigureLogger)}: Configuring named logger " +
+                $" '{loggerName}'. There are {_loggers.Count} {nameof(IModifLogger)} already configured.");
+#endif
+            return _loggers.AddOrUpdate(modId, 
+                CreateLogger(modId, loggerName, logLevel),
+                (k, v) => UpdateLogLevel(modId, (Logger)v, logLevel));
         }
-        public static IModifLogger GetLogger()
+        public static IModifLogger GetLogger(string modId)
         {
-            return _logger ?? _defaultLogger;
+            return _loggers.TryGetValue(modId, out var logger) ? logger : new Logger(LogLevel.Warning, modId);
+        }
+        private static Logger CreateLogger(string modId, string loggerName, LogLevel logLevel)
+        {
+            var logger = new Logger(logLevel, loggerName);
+            LoggerEvents.RaiseLoggerCreated(modId, logger);
+            return logger;
+        }
+        private static Logger UpdateLogLevel(string modId, Logger logger, LogLevel logLevel)
+        {
+            if (logger.LogLevel != logLevel)
+            {
+                logger.LogLevel = logLevel;
+                LoggerEvents.RaiseLoggerConfigured(modId, logger);
+            }
+            return logger;
         }
     }
 }

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/PatchLogger.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/PatchLogger.cs
@@ -8,7 +8,7 @@ namespace ModifAmorphic.Outward.Logging
     internal class PatchLogger : IModifLogger
     {
 
-        public string LoggerName => DebugLoggerInfo.ModName;
+        public string LoggerName => "ModifAmorphic-PatchLogger";
 
         public LogLevel LogLevel => LogLevel.Warning;
 

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/PatchLogger.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/PatchLogger.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ModifAmorphic.Outward.Logging
+{
+    internal class PatchLogger : IModifLogger
+    {
+
+        public string LoggerName => DebugLoggerInfo.ModName;
+
+        public LogLevel LogLevel => LogLevel.Warning;
+
+        public ConcurrentDictionary<string, Func<IModifLogger>> _loggerFactories = new ConcurrentDictionary<string, Func<IModifLogger>>();
+
+        public void AddOrUpdateLogger(string modId, Func<IModifLogger> loggerFactory)
+        {
+            _loggerFactories.AddOrUpdate(modId, loggerFactory, (k, v) => loggerFactory);
+        }
+        public void RemoveLogger(string loggerName)
+        {
+            _loggerFactories.TryRemove(loggerName, out _);
+        }
+        public void Log(LogLevel logLevel, string message)
+        {
+            foreach (var logger in _loggerFactories.Values)
+                logger?.Invoke().Log(logLevel, message);
+        }
+        public void LogTrace(string message)
+        {
+            Log(LogLevel.Trace, message);
+        }
+        public void LogDebug(string message)
+        {
+            Log(LogLevel.Debug, message);
+        }
+        public void LogInfo(string message)
+        {
+            Log(LogLevel.Info, message);
+        }
+        public void LogWarning(string message)
+        {
+            Log(LogLevel.Warning, message);
+        }
+        public void LogError(string message)
+        {
+            Log(LogLevel.Error, message);
+        }
+        public void LogException(Exception ex)
+        {
+            Log(LogLevel.Error, ex.ToString());
+        }
+        public void LogException(string message, Exception ex)
+        {
+            foreach (var logger in _loggerFactories.Values)
+                logger?.Invoke().LogException(message, ex);
+        }
+    }
+}

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/PatchLoggerAttribute.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Logging/PatchLoggerAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ModifAmorphic.Outward.Logging
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    internal class PatchLoggerAttribute : Attribute
+    {
+    }
+}

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/ModifAmorphic.Outward.Shared.csproj
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/ModifAmorphic.Outward.Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>ModifAmorphic.Outward.v0_0_0_4</AssemblyName>
+    <AssemblyName>ModifAmorphic.Outward.v0_0_0_5</AssemblyName>
     <RootNamespace>ModifAmorphic.Outward</RootNamespace>
     <Authors>ModifAmorphic.Outward</Authors>
     <Product>ModifAmorphic.Outward</Product>

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/ModifAmorphic.Outward.Shared.csproj
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/ModifAmorphic.Outward.Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>ModifAmorphic.Outward.v0_0_0_3</AssemblyName>
+    <AssemblyName>ModifAmorphic.Outward.v0_0_0_4</AssemblyName>
     <RootNamespace>ModifAmorphic.Outward</RootNamespace>
     <Authors>ModifAmorphic.Outward</Authors>
     <Product>ModifAmorphic.Outward</Product>
@@ -42,6 +42,10 @@
       <HintPath>..\..\outward-shared-assemblies\UnityEngine.CoreModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Modules\Save\Patches\" />
   </ItemGroup>
 
 </Project>

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/ModifAmorphic.Outward.Shared.csproj
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/ModifAmorphic.Outward.Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>ModifAmorphic.Outward.v0_0_0_5</AssemblyName>
+    <AssemblyName>ModifAmorphic.Outward.v0_0_0_6</AssemblyName>
     <RootNamespace>ModifAmorphic.Outward</RootNamespace>
     <Authors>ModifAmorphic.Outward</Authors>
     <Product>ModifAmorphic.Outward</Product>

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/CharacterInstances.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/CharacterInstances.cs
@@ -1,11 +1,10 @@
 ﻿using ModifAmorphic.Outward.Logging;
-using ModifAmorphic.Outward.SkillSchools.Patches;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
-namespace ModifAmorphic.Outward.Modules.Instances
+namespace ModifAmorphic.Outward.Modules.Character
 {
     public class CharacterInstances : IModifModule
     {

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/SkillSchools/Patches/CharacterManagerPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/SkillSchools/Patches/CharacterManagerPatches.cs
@@ -8,20 +8,22 @@ namespace ModifAmorphic.Outward.Modules.Character
     [HarmonyPatch(typeof(CharacterManager))]
     internal static class CharacterManagerPatches
     {
-        private static Func<IModifLogger> _getLogger;
-        private static IModifLogger Logger => _getLogger?.Invoke() ?? new NullLogger();
+        [PatchLogger]
+        private static IModifLogger Logger { get; set; } = new NullLogger();
         public static event Action<CharacterManager> AwakeAfter;
 
 
-        [EventSubscription]
-        public static void SubscribeToEvents()
-        {
-            LoggerEvents.LoggerReady += (object sender, Func<IModifLogger> getLogger) => _getLogger = getLogger;
-        }
+        //[EventSubscription]
+        //public static void SubscribeToEvents()
+        //{
+        //    LoggerEvents.LoggerConfigured += (object sender, Func<IModifLogger> getLogger) => _getLogger = getLogger;
+        //}
 
         [HarmonyPatch("Awake", MethodType.Normal)]
         [HarmonyPostfix]
+#pragma warning disable IDE0051 // Remove unused private members
         private static void AwakePostfix(CharacterManager __instance)
+#pragma warning restore IDE0051 // Remove unused private members
         {
             AwakeAfter?.Invoke(__instance);
         }

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/SkillSchools/Patches/CharacterManagerPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/SkillSchools/Patches/CharacterManagerPatches.cs
@@ -3,14 +3,14 @@ using ModifAmorphic.Outward.Events;
 using ModifAmorphic.Outward.Logging;
 using System;
 
-namespace ModifAmorphic.Outward.SkillSchools.Patches
+namespace ModifAmorphic.Outward.Modules.Character
 {
-    [HarmonyPatch(typeof(SkillTreeHolder))]
-    internal static class SkillTreeHolderPatches
+    [HarmonyPatch(typeof(CharacterManager))]
+    internal static class CharacterManagerPatches
     {
         private static Func<IModifLogger> _getLogger;
         private static IModifLogger Logger => _getLogger?.Invoke() ?? new NullLogger();
-        public static event Action<SkillTreeHolder> AwakeAfter;
+        public static event Action<CharacterManager> AwakeAfter;
 
 
         [EventSubscription]
@@ -21,7 +21,7 @@ namespace ModifAmorphic.Outward.SkillSchools.Patches
 
         [HarmonyPatch("Awake", MethodType.Normal)]
         [HarmonyPostfix]
-        private static void AwakePostfix(SkillTreeHolder __instance)
+        private static void AwakePostfix(CharacterManager __instance)
         {
             AwakeAfter?.Invoke(__instance);
         }

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/SkillSchools/Patches/SkillTreeHolderPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/SkillSchools/Patches/SkillTreeHolderPatches.cs
@@ -8,20 +8,22 @@ namespace ModifAmorphic.Outward.Modules.Character
     [HarmonyPatch(typeof(SkillTreeHolder))]
     internal static class SkillTreeHolderPatches
     {
-        private static Func<IModifLogger> _getLogger;
-        private static IModifLogger Logger => _getLogger?.Invoke() ?? new NullLogger();
+        [PatchLogger]
+        private static IModifLogger Logger { get; set; } = new NullLogger();
         public static event Action<SkillTreeHolder> AwakeAfter;
 
 
-        [EventSubscription]
-        public static void SubscribeToEvents()
-        {
-            LoggerEvents.LoggerReady += (object sender, Func<IModifLogger> getLogger) => _getLogger = getLogger;
-        }
+        //[EventSubscription]
+        //public static void SubscribeToEvents()
+        //{
+        //    LoggerEvents.LoggerConfigured += (object sender, Func<IModifLogger> getLogger) => _getLogger = getLogger;
+        //}
 
         [HarmonyPatch("Awake", MethodType.Normal)]
         [HarmonyPostfix]
+#pragma warning disable IDE0051 // Remove unused private members
         private static void AwakePostfix(SkillTreeHolder __instance)
+#pragma warning restore IDE0051 // Remove unused private members
         {
             AwakeAfter?.Invoke(__instance);
         }

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/SkillSchools/Patches/SkillTreeHolderPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/SkillSchools/Patches/SkillTreeHolderPatches.cs
@@ -3,14 +3,14 @@ using ModifAmorphic.Outward.Events;
 using ModifAmorphic.Outward.Logging;
 using System;
 
-namespace ModifAmorphic.Outward.SkillSchools.Patches
+namespace ModifAmorphic.Outward.Modules.Character
 {
-    [HarmonyPatch(typeof(CharacterManager))]
-    internal static class CharacterManagerPatches
+    [HarmonyPatch(typeof(SkillTreeHolder))]
+    internal static class SkillTreeHolderPatches
     {
         private static Func<IModifLogger> _getLogger;
         private static IModifLogger Logger => _getLogger?.Invoke() ?? new NullLogger();
-        public static event Action<CharacterManager> AwakeAfter;
+        public static event Action<SkillTreeHolder> AwakeAfter;
 
 
         [EventSubscription]
@@ -21,7 +21,7 @@ namespace ModifAmorphic.Outward.SkillSchools.Patches
 
         [HarmonyPatch("Awake", MethodType.Normal)]
         [HarmonyPostfix]
-        private static void AwakePostfix(CharacterManager __instance)
+        private static void AwakePostfix(SkillTreeHolder __instance)
         {
             AwakeAfter?.Invoke(__instance);
         }

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/SkillSchools/SchoolService.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Character/SkillSchools/SchoolService.cs
@@ -1,11 +1,10 @@
 ﻿using ModifAmorphic.Outward.Logging;
-using ModifAmorphic.Outward.Modules.Instances;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace ModifAmorphic.Outward.SkillSchools
+namespace ModifAmorphic.Outward.Modules.Character
 {
     public class SchoolService
     {

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Items/PreFabricator.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Items/PreFabricator.cs
@@ -31,11 +31,11 @@ namespace ModifAmorphic.Outward.Modules.Items
         private readonly Dictionary<int, ItemLocalization> _itemLocalizations = new Dictionary<int, ItemLocalization>();
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal PreFabricator(string modId, ServicesProvider services)
+        internal PreFabricator(string modId, Func<ResourcesPrefabManager> prefabManagerFactory, Func<IModifLogger> loggerFactory)
         {
             this._modId = modId;
-            this._loggerFactory = services.GetService<IModifLogger>;
-            this._prefabManagerFactory = services.GetService<ResourcesPrefabManager>;
+            this._loggerFactory = loggerFactory;
+            this._prefabManagerFactory = prefabManagerFactory;
             LocalizationManagerPatches.LoadItemLocalizationAfter += (itemLocalizations) =>
                     RegisterItemLocalizations(_itemLocalizations, itemLocalizations);
         }

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/ModifModules.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/ModifModules.cs
@@ -1,10 +1,8 @@
-﻿using HarmonyLib;
-using ModifAmorphic.Outward.Events;
-using ModifAmorphic.Outward.Logging;
-using ModifAmorphic.Outward.Modules.Instances;
+﻿using ModifAmorphic.Outward.Logging;
+using ModifAmorphic.Outward.Modules.Character;
 using ModifAmorphic.Outward.Modules.Items;
+using ModifAmorphic.Outward.Modules.QuickSlots;
 using System;
-using System.Collections.Concurrent;
 
 namespace ModifAmorphic.Outward.Modules
 {

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/ModifModules.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/ModifModules.cs
@@ -20,28 +20,19 @@ namespace ModifAmorphic.Outward.Modules
         public static QuickSlotExtender GetQuickSlotExtenderModule(string modId)
         {
             return ModuleService.GetModule(modId, () => 
-                new QuickSlotExtender(ModuleService.GetLoggerFactory(modId)));
+                new QuickSlotExtender(() => LoggerFactory.GetLogger(modId)));
         }
         public static CharacterInstances GetCharacterInstancesModule(string modId)
         {
             return ModuleService.GetModule<CharacterInstances>(modId, () =>
-                new CharacterInstances(ModuleService.GetLoggerFactory(modId)));
+                new CharacterInstances(() => LoggerFactory.GetLogger(modId)));
         }
-        public static PreFabricator GetPreFabricatorModule(string modId, ServicesProvider servicesProvider)
+        public static PreFabricator GetPreFabricatorModule(string modId)
         {
             return ModuleService.GetModule<PreFabricator>(modId, () =>
-                new PreFabricator(modId, servicesProvider));
+                new PreFabricator(modId, 
+                    () => ResourcesPrefabManager.Instance, 
+                    () => LoggerFactory.GetLogger(modId)));
         }
-
-        public static void ConfigureLogging(string modId, Func<IModifLogger> loggerFactory)
-        {
-            ModuleService.ConfigureLogging(modId, loggerFactory);
-        }
-        public static void ConfigureLogging(string modId, string loggerName, LogLevel logLevel)
-        {
-            ModuleService.ConfigureLogging(modId, () => new Logger(logLevel, loggerName));
-        }
-
-        
     }
 }

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Events/QuickSlotExtendedArgs.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Events/QuickSlotExtendedArgs.cs
@@ -1,7 +1,6 @@
-﻿using ModifAmorphic.Outward.Models;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
-namespace ModifAmorphic.Outward.Events
+namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
 {
     class QuickSlotExtendedArgs //: EventArgs
     {

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Events/QuickSlotExtenderEvents.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Events/QuickSlotExtenderEvents.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace ModifAmorphic.Outward.Events
+namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
 {
     static class QuickSlotExtenderEvents
     {

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Models/ExtendedQuickSlot.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Models/ExtendedQuickSlot.cs
@@ -1,4 +1,4 @@
-﻿namespace ModifAmorphic.Outward.Models
+﻿namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
 {
     internal class ExtendedQuickSlot
     {

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/MoreQuickslotsLocalizationListener.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/MoreQuickslotsLocalizationListener.cs
@@ -3,7 +3,7 @@ using ModifAmorphic.Outward.Logging;
 using System.Collections.Generic;
 using System.Text;
 
-namespace ModifAmorphic.Outward.KeyBindings
+namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
 {
     internal class MoreQuickslotsLocalizationListener : ILocalizeListener
     {

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/CharacterQuickSlotManagerPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/CharacterQuickSlotManagerPatches.cs
@@ -15,15 +15,14 @@ namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
     internal static class CharacterQuickSlotManagerPatches
     {
         private static int _quickslotsToAdd;
-        private static Func<IModifLogger> _getLogger;
-        private static IModifLogger Logger => _getLogger?.Invoke() ?? new NullLogger();
-        private static void LoggerEvents_LoggerLoaded(object sender, Func<IModifLogger> getLogger) => _getLogger = getLogger;
+        [PatchLogger]
+        private static IModifLogger Logger { get; set; } = new NullLogger();
         private static void QuickSlotExtenderEvents_SlotsChanged(object sender, QuickSlotExtendedArgs e) => (_quickslotsToAdd) = (e.ExtendedQuickSlots.Count());
 
         [EventSubscription]
         public static void SubscribeToEvents()
         {
-            LoggerEvents.LoggerReady += LoggerEvents_LoggerLoaded;
+            //LoggerEvents.LoggerConfigured += LoggerEvents_LoggerLoaded;
             QuickSlotExtenderEvents.SlotsChanged += QuickSlotExtenderEvents_SlotsChanged;
         }
 

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/CharacterQuickSlotManagerPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/CharacterQuickSlotManagerPatches.cs
@@ -5,9 +5,8 @@ using System;
 using System.Linq;
 using System.Text;
 using UnityEngine;
-using ModifAmorphicLogging = ModifAmorphic.Outward.Logging;
 
-namespace ModifAmorphic.Outward.KeyBindings.Patches
+namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
 { 
     /// <summary>
     /// This class is responsible for adding extra quickslots to the character's QuickSlotManager.

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/KeyboardQuickSlotPanelPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/KeyboardQuickSlotPanelPatches.cs
@@ -3,9 +3,8 @@ using ModifAmorphic.Outward.Events;
 using ModifAmorphic.Outward.Logging;
 using System;
 using System.Linq;
-using ModifAmorphicLogging = ModifAmorphic.Outward.Logging;
 
-namespace ModifAmorphic.Outward.KeyBindings.Patches
+namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
 {
     [HarmonyPatch(typeof(KeyboardQuickSlotPanel), "InitializeQuickSlotDisplays")]
     internal static class KeyboardQuickSlotPanelPatches

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/KeyboardQuickSlotPanelPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/KeyboardQuickSlotPanelPatches.cs
@@ -12,15 +12,13 @@ namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
         private static int _quickslotsToAdd;
         private static int _exQuickslotStartId;
 
-        private static Func<IModifLogger> _getLogger;
-        private static IModifLogger Logger => _getLogger?.Invoke() ?? new NullLogger();
-        private static void LoggerEvents_LoggerLoaded(object sender, Func<IModifLogger> getLogger) => _getLogger = getLogger;
+        [PatchLogger]
+        private static IModifLogger Logger { get; set; } = new NullLogger();
         private static void QuickSlotExtenderEvents_SlotsChanged(object sender, QuickSlotExtendedArgs e) => (_quickslotsToAdd, _exQuickslotStartId) = (e.ExtendedQuickSlots.Count(), e.StartId);
 
         [EventSubscription]
         public static void SubscribeToEvents()
         {
-            LoggerEvents.LoggerReady += LoggerEvents_LoggerLoaded;
             QuickSlotExtenderEvents.SlotsChanged += QuickSlotExtenderEvents_SlotsChanged;
         }
 

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/LocalCharacterControlPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/LocalCharacterControlPatches.cs
@@ -18,16 +18,16 @@ namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
         //private static SortedDictionary<int, string> _exQuickSlots = new SortedDictionary<int, string>();
         private static IEnumerable<ExtendedQuickSlot> _exQuickSlots = new List<ExtendedQuickSlot>();
 
-        private static Func<IModifLogger> _getLogger;
-        private static IModifLogger Logger => _getLogger?.Invoke()?? new NullLogger();
-        private static void LoggerEvents_LoggerLoaded(object sender, Func<IModifLogger> getLogger) => _getLogger = getLogger;
+        [PatchLogger]
+        private static IModifLogger Logger { get; set; } = new NullLogger();
 
         private static void QuickSlotExtenderEvents_SlotsChanged(object sender, QuickSlotExtendedArgs e) => _exQuickSlots = e.ExtendedQuickSlots;
+
 
         [EventSubscription]
         public static void SubscribeToEvents()
         {
-            LoggerEvents.LoggerReady += LoggerEvents_LoggerLoaded;
+            //LoggerEvents.LoggerConfigured += LoggerEvents_LoggerLoaded;
             QuickSlotExtenderEvents.SlotsChanged += QuickSlotExtenderEvents_SlotsChanged;
         }
 

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/LocalCharacterControlPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/LocalCharacterControlPatches.cs
@@ -2,7 +2,6 @@
 using ModifAmorphic.Outward.Events;
 using ModifAmorphic.Outward.Extensions;
 using ModifAmorphic.Outward.Logging;
-using ModifAmorphic.Outward.Models;
 #if DEBUG
 using Rewired;
 #endif
@@ -10,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ModifAmorphic.Outward.KeyBindings.Patches
+namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
 {
     [HarmonyPatch]
     internal static class LocalCharacterControlPatches

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/LocalizationManagerPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/LocalizationManagerPatches.cs
@@ -12,9 +12,8 @@ namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
     {
         static readonly List<ILocalizeListener> _customLocalizationListeners = new List<ILocalizeListener>();
 
-        private static Func<IModifLogger> _getLogger;
-        private static IModifLogger Logger => _getLogger?.Invoke() ?? new NullLogger();
-        private static void LoggerEvents_LoggerLoaded(object sender, Func<IModifLogger> getLogger) => _getLogger = getLogger;
+        [PatchLogger]
+        private static IModifLogger Logger { get; set; } = new NullLogger();
 
         private static void QuickSlotExtenderEvents_SlotsChanged(object sender, QuickSlotExtendedArgs e)
         {
@@ -26,7 +25,7 @@ namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
         [EventSubscription]
         public static void SubscribeToEvents()
         {
-            LoggerEvents.LoggerReady += LoggerEvents_LoggerLoaded;
+            //LoggerEvents.LoggerConfigured += LoggerEvents_LoggerLoaded;
             QuickSlotExtenderEvents.SlotsChanged += QuickSlotExtenderEvents_SlotsChanged;
         }
 

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/LocalizationManagerPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/KeyBindings/Patches/LocalizationManagerPatches.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ModifAmorphic.Outward.KeyBindings.Patches
+namespace ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings
 {
     [HarmonyPatch(typeof(LocalizationManager), "Awake")]
     internal static class LocalizationManagerPatches

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/QuickSlotExtender.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/QuickSlots/QuickSlotExtender.cs
@@ -1,15 +1,12 @@
-﻿using ModifAmorphic.Outward.Events;
-using ModifAmorphic.Outward.KeyBindings.Patches;
-using ModifAmorphic.Outward.Logging;
-using ModifAmorphic.Outward.Models;
-using ModifAmorphic.Outward;
+﻿using ModifAmorphic.Outward.Logging;
+using ModifAmorphic.Outward.Modules.QuickSlots.KeyBindings;
 using SideLoader;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
-namespace ModifAmorphic.Outward.Modules
+namespace ModifAmorphic.Outward.Modules.QuickSlots
 {
     public class QuickSlotExtender : IModifModule
     {

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Save/IModifSave.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Save/IModifSave.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ModifAmorphic.Outward.Modules.Save
+{
+    public interface IModifSave<T>
+    {
+        string SaveName { get; }
+
+        string Serialize();
+        T Deserialize();
+    }
+}

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Save/SaveModule.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Modules/Save/SaveModule.cs
@@ -1,0 +1,39 @@
+﻿using Localizer;
+using ModifAmorphic.Outward.Patches;
+using ModifAmorphic.Outward.Logging;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using UnityEngine;
+using ModifAmorphic.Outward.Extensions;
+using System.Reflection;
+
+namespace ModifAmorphic.Outward.Modules.Items
+{
+    public class SaveModule : IModifModule
+    {
+        private readonly string _modId;
+        private readonly Func<IModifLogger> _loggerFactory;
+        private IModifLogger Logger => _loggerFactory.Invoke();
+
+        public HashSet<Type> PatchDependencies => new HashSet<Type>() {
+            typeof(LocalizationManagerPatches)
+        };
+
+        public HashSet<Type> EventSubscriptions => new HashSet<Type>() {
+            typeof(LocalizationManagerPatches)
+        };
+
+        private Transform _parentTransform;
+        private readonly Dictionary<int, ItemLocalization> _itemLocalizations = new Dictionary<int, ItemLocalization>();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal SaveModule(string modId, Func<IModifLogger> loggerFactory)
+        {
+            this._modId = modId;
+            this._loggerFactory = loggerFactory;
+            
+        }
+    }
+}

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Patches/LocalizationManagerPatches.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Patches/LocalizationManagerPatches.cs
@@ -11,21 +11,16 @@ namespace ModifAmorphic.Outward.Patches
     [HarmonyPatch(typeof(LocalizationManager))]
     public static class LocalizationManagerPatches
     {
-        private static Func<IModifLogger> _getLogger;
-        private static IModifLogger Logger => _getLogger?.Invoke() ?? new NullLogger();
-        private static void LoggerEvents_LoggerLoaded(object sender, Func<IModifLogger> getLogger) => _getLogger = getLogger;
+        [PatchLogger]
+        private static IModifLogger Logger { get; set; } = new NullLogger();
 
         public static event Action<Dictionary<int, ItemLocalization>> LoadItemLocalizationAfter;
 
-        [EventSubscription]
-        public static void SubscribeToEvents()
-        {
-            LoggerEvents.LoggerReady += LoggerEvents_LoggerLoaded;
-        }
-
         [HarmonyPatch("LoadItemLocalization")]
         [HarmonyPostfix]
+#pragma warning disable IDE0051 // Remove unused private members
         private static void LoadItemLocalizationPostfix(ref Dictionary<int, ItemLocalization> ___m_itemLocalization)
+#pragma warning restore IDE0051 // Remove unused private members
         {
             LoadItemLocalizationAfter?.Invoke(___m_itemLocalization);
         }

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Patches/PatchLoggerRegisterService.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Patches/PatchLoggerRegisterService.cs
@@ -7,6 +7,9 @@ namespace ModifAmorphic.Outward.Events
 {
     internal static class PatchLoggerRegisterService
     {
+#if DEBUG
+        private readonly static IModifLogger _logger = LoggerFactory.ConfigureLogger(DebugLoggerInfo.ModId, DebugLoggerInfo.ModName, DebugLoggerInfo.DebugLogLevel);
+#endif
         private static readonly object lockRegistration = new object();
         public static void AddPatchLogger(Type classType, string modId, Func<IModifLogger> loggerFactory)
         {
@@ -15,7 +18,7 @@ namespace ModifAmorphic.Outward.Events
                 if (!classType.IsClass)
                     throw new ArgumentException($"{nameof(classType)} must be a class.", nameof(classType));
 #if DEBUG
-                UnityEngine.Debug.Log($"[{DebugLoggerInfo.ModName}][Trace] - {nameof(PatchLoggerRegisterService)}::{nameof(AddPatchLogger)}:" +
+                _logger.LogDebug($"{nameof(PatchLoggerRegisterService)}::{nameof(AddPatchLogger)}:" +
                     $" Adding patch logger factory with loggerName: {modId} for type {classType.Name}.");
 #endif
 
@@ -27,7 +30,7 @@ namespace ModifAmorphic.Outward.Events
                 foreach (var p in patchLoggerProps)
                 {
 #if DEBUG
-                    UnityEngine.Debug.Log($"[{DebugLoggerInfo.ModName}][Trace] - {nameof(PatchLoggerRegisterService)}::{nameof(AddPatchLogger)}:" +
+                    _logger.LogTrace($"{nameof(PatchLoggerRegisterService)}::{nameof(AddPatchLogger)}:" +
                         $" Property p.GetValue(null) as PatchLogger is {(p.GetValue(null) as PatchLogger == null ? "null" : "not null")}." +
                         $" propery name is {p?.Name}");
 #endif
@@ -43,7 +46,7 @@ namespace ModifAmorphic.Outward.Events
                 foreach (var f in patchLoggerFields)
                 {
 #if DEBUG
-                    UnityEngine.Debug.Log($"[{DebugLoggerInfo.ModName}][Trace] -{nameof(PatchLoggerRegisterService)}::{nameof(AddPatchLogger)}:" +
+                    _logger.LogTrace($"{nameof(PatchLoggerRegisterService)}::{nameof(AddPatchLogger)}:" +
                         $" Field f.GetValue(null) as PatchLogger is {(f.GetValue(null) as PatchLogger == null ? "null" : "not null")}." +
                         $" propery name is {f?.Name}");
 #endif

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Patches/PatchLoggerRegisterService.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Patches/PatchLoggerRegisterService.cs
@@ -1,0 +1,61 @@
+﻿using ModifAmorphic.Outward.Logging;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ModifAmorphic.Outward.Events
+{
+    internal static class PatchLoggerRegisterService
+    {
+        private static readonly object lockRegistration = new object();
+        public static void AddPatchLogger(Type classType, string modId, Func<IModifLogger> loggerFactory)
+        {
+            lock (lockRegistration)
+            {
+                if (!classType.IsClass)
+                    throw new ArgumentException($"{nameof(classType)} must be a class.", nameof(classType));
+#if DEBUG
+                UnityEngine.Debug.Log($"[{DebugLoggerInfo.ModName}][Trace] - {nameof(PatchLoggerRegisterService)}::{nameof(AddPatchLogger)}:" +
+                    $" Adding patch logger factory with loggerName: {modId} for type {classType.Name}.");
+#endif
+
+                var patchLoggerProps = classType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                        .Where(p => p.GetCustomAttributes(typeof(PatchLoggerAttribute), false).Any());
+                var patchLoggerFields = classType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                        .Where(m => m.GetCustomAttributes(typeof(PatchLoggerAttribute), false).Any());
+
+                foreach (var p in patchLoggerProps)
+                {
+#if DEBUG
+                    UnityEngine.Debug.Log($"[{DebugLoggerInfo.ModName}][Trace] - {nameof(PatchLoggerRegisterService)}::{nameof(AddPatchLogger)}:" +
+                        $" Property p.GetValue(null) as PatchLogger is {(p.GetValue(null) as PatchLogger == null ? "null" : "not null")}." +
+                        $" propery name is {p?.Name}");
+#endif
+                    var patchLogger = p.GetValue(null) as PatchLogger;
+                    if (patchLogger == null)
+                    {
+                        patchLogger = new PatchLogger();
+                        p.SetValue(null, patchLogger);
+                    }
+                    patchLogger.AddOrUpdateLogger(modId, loggerFactory);
+                    
+                }
+                foreach (var f in patchLoggerFields)
+                {
+#if DEBUG
+                    UnityEngine.Debug.Log($"[{DebugLoggerInfo.ModName}][Trace] -{nameof(PatchLoggerRegisterService)}::{nameof(AddPatchLogger)}:" +
+                        $" Field f.GetValue(null) as PatchLogger is {(f.GetValue(null) as PatchLogger == null ? "null" : "not null")}." +
+                        $" propery name is {f?.Name}");
+#endif
+                    var patchLogger = f.GetValue(null) as PatchLogger;
+                    if (patchLogger == null)
+                    {
+                        patchLogger = new PatchLogger();
+                        f.SetValue(null, patchLogger);
+                    }
+                    patchLogger.AddOrUpdateLogger(modId, loggerFactory);
+                }
+            }
+        }
+    }
+}

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/ServicesProvider.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/ServicesProvider.cs
@@ -81,12 +81,12 @@ namespace ModifAmorphic.Outward
 #if DEBUG
             Logger.LogTrace($"{nameof(ServicesProvider)}::{nameof(TryGetService)}<T>: Type: {typeof(T).Name}");
 #endif
-            service = default(T);
+            service = default;
             if (!_serviceFactories.TryGetValue(typeof(T), out var serviceDelegate))
                 return false;
 
             service = (T)serviceDelegate.DynamicInvoke();
-            return !EqualityComparer<T>.Default.Equals(service, default(T));
+            return !EqualityComparer<T>.Default.Equals(service, default);
         }
         
         //Exists so TryGetService can log trace events without creating an infinite loop.


### PR DESCRIPTION
Changes to use BepInEx logger over UnityEngine debug
Several fixes for when multiple mods are using the same assembly
Coroutines now timeout after X real world seconds if no tick wait time provided
Namespace / project reorganization. 