### PR TITLE
Fix for binding raising events before binding is complete

### DIFF
--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Config/ConfigSettingsService.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Config/ConfigSettingsService.cs
@@ -24,7 +24,7 @@ namespace ModifAmorphic.Outward.Config
 #endif
         }
 
-        public ConfigSetting<T> BindConfigSetting<T>(ConfigSetting<T> configSetting, Action<SettingValueChangedArgs<T>> onValueChange = null, bool bindRaisesChangeEvent = false, bool suppressValueChanveEvents = false)
+        public ConfigSetting<T> BindConfigSetting<T>(ConfigSetting<T> configSetting, Action<SettingValueChangedArgs<T>> onValueChange = null, bool bindRaisesChangeEvent = false, bool suppressValueChangeEvents = false)
         {
             //This TryGetEntry is pretty much a useless check because Bind does it anyway even though
             //the documentation suggests otherwise.
@@ -33,12 +33,15 @@ namespace ModifAmorphic.Outward.Config
             {
                 configEntry = Config.Bind(configSetting.ToConfigDefinition(), configSetting.DefaultValue, configSetting.ToConfigDescription());
             }
-            configSetting.SuppressValueChangedEvents = suppressValueChanveEvents;
+            //Surpress all change events binding is complete.
+            configSetting.SuppressValueChangedEvents = true;
             configSetting.BoundConfigEntry = configEntry;
             configSetting.IsVisible = configEntry.Description.ConfigurationManagerAttributes().Browsable ?? true;
             configSetting.ValueChanged += (object sender, SettingValueChangedArgs<T> e) => onValueChange?.Invoke(e);
             configEntry.SettingChanged += (object sender, EventArgs e) => configSetting.Value = configSetting.BoundConfigEntry.Value;
             configSetting.Value = configSetting.BoundConfigEntry.Value;
+            //after binding, set this to the desired value being passed in
+            configSetting.SuppressValueChangedEvents = suppressValueChangeEvents;
 #if DEBUG
             _logger.LogDebug($"Bound ConfigSetting: {configSetting.Name} to ConfigEntry {configEntry.Definition.Key} with value {configEntry.Value}");
 #endif
@@ -154,7 +157,7 @@ namespace ModifAmorphic.Outward.Config
         /// <param name="configSetting">The ConfigSetting to hide.</param>
         public void HideSettingAndRefresh<T>(ConfigSetting<T> configSetting)
         {
-            if (configSetting.IsVisible || (configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes().Browsable ?? true))
+            if (configSetting.IsVisible || (configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes()?.Browsable ?? true))
             {
                 configSetting.Hide();
                 _configManagerService.RefreshConfigManager();
@@ -167,7 +170,7 @@ namespace ModifAmorphic.Outward.Config
         /// <param name="configSetting">The ConfigSetting to show.</param>
         public void ShowSettingAndRefresh<T>(ConfigSetting<T> configSetting)
         {
-            if (!configSetting.IsVisible || !(configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes().Browsable ?? true))
+            if (!configSetting.IsVisible || !(configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes()?.Browsable ?? true))
             {
                 configSetting.Show();
                 _configManagerService.RefreshConfigManager();

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Config/Extensions/ConfigDescriptionExtensions.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Config/Extensions/ConfigDescriptionExtensions.cs
@@ -10,5 +10,12 @@ namespace ModifAmorphic.Outward.Config.Extensions
             return configDescription.Tags.FirstOrDefault(t =>
                 t.GetType() == typeof(ConfigurationManagerAttributes)) as ConfigurationManagerAttributes;
         }
+        public static bool TryGetConfigurationManagerAttributes(this ConfigDescription configDescription, out ConfigurationManagerAttributes configurationManagerAttributes)
+        {
+            configurationManagerAttributes = configDescription.Tags.FirstOrDefault(t =>
+                t.GetType() == typeof(ConfigurationManagerAttributes)) as ConfigurationManagerAttributes;
+
+            return configurationManagerAttributes != default;
+        }
     }
 }

--- a/Outward.Shared/ModifAmorphic.Outward.Shared/Config/Extensions/ConfigSettingExtensions.cs
+++ b/Outward.Shared/ModifAmorphic.Outward.Shared/Config/Extensions/ConfigSettingExtensions.cs
@@ -33,23 +33,29 @@ namespace ModifAmorphic.Outward.Config.Extensions
             if (configSetting.BoundConfigEntry == null)
                 throw new InvalidOperationException($"Cannot hide unbound ConfigSettings.  ConfigSetting {configSetting.Name} has not been bound to a Configuration Entry.");
             configSetting.IsVisible = false;
-            configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes().Browsable = configSetting.IsVisible;
+
+            if (configSetting.BoundConfigEntry.Description
+                .TryGetConfigurationManagerAttributes(out var confAttributes))
+                confAttributes.Browsable = configSetting.IsVisible;
 #if DEBUG
             _logger.LogDebug($"Hid ConfigSetting {configSetting.Name}. " +
                 $"IsVisible = {configSetting.IsVisible}. " +
-                $"Browsable = {configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes().Browsable}.");
+                $"Browsable = {configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes()?.Browsable}.");
 #endif
         }
         public static void Show<T>(this ConfigSetting<T> configSetting)
         {
             if (configSetting.BoundConfigEntry == null)
                 throw new InvalidOperationException($"Cannot hide unbound ConfigSettings.  ConfigSetting {configSetting.Name} has not been bound to a Configuration Entry.");
+
             configSetting.IsVisible = true;
-            configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes().Browsable = configSetting.IsVisible;
+            if (configSetting.BoundConfigEntry.Description
+                .TryGetConfigurationManagerAttributes(out var confAttributes))
+                confAttributes.Browsable = configSetting.IsVisible;
 #if DEBUG
             _logger.LogDebug($"Showed ConfigSetting {configSetting.Name}. " +
                 $"IsVisible = {configSetting.IsVisible}. " +
-                $"Browsable = {configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes().Browsable}.");
+                $"Browsable = {configSetting.BoundConfigEntry.Description.ConfigurationManagerAttributes()?.Browsable}.");
 #endif
         }
     }


### PR DESCRIPTION
Fix to suppress value change events before while a config setting is being bound