### PR TITLE
Mods/actionui

### DIFF
--- a/ActionUI/ActionUI.Plugin/ActionUIPlugin.cs
+++ b/ActionUI/ActionUI.Plugin/ActionUIPlugin.cs
@@ -32,6 +32,7 @@ namespace ModifAmorphic.Outward.ActionUI
                 harmony.PatchAll(typeof(PauseMenuPatches));
                 harmony.PatchAll(typeof(SplitPlayerPatches));
                 harmony.PatchAll(typeof(LobbySystemPatches));
+                harmony.PatchAll(typeof(CharacterUIPatches));
 
                 var startup = new Startup();
                 logger.LogInfo($"Starting {ModInfo.ModName} {ModInfo.ModVersion}...");

--- a/ActionUI/ActionUI.Plugin/DurabilityDisplayStartup.cs
+++ b/ActionUI/ActionUI.Plugin/DurabilityDisplayStartup.cs
@@ -31,7 +31,7 @@ namespace ModifAmorphic.Outward.ActionUI
             _harmony.PatchAll(typeof(EquipmentPatches));
 
             _services
-                     .AddSingleton(new DurabilityDisplayService(_loggerFactory));
+                     .AddSingleton(new DurabilityDisplayService(_services.GetService<PlayerMenuService>(), _loggerFactory));
 
         }
     }

--- a/ActionUI/ActionUI.Plugin/Extensions/ItemExtensions.cs
+++ b/ActionUI/ActionUI.Plugin/Extensions/ItemExtensions.cs
@@ -1,6 +1,4 @@
-﻿using ModifAmorphic.Outward.ActionUI.Models;
-
-namespace ModifAmorphic.Outward.ActionUI.Extensions
+﻿namespace ModifAmorphic.Outward.ActionUI.Extensions
 {
     internal static class ItemExtensions
     {

--- a/ActionUI/ActionUI.Plugin/HotbarsStartup.cs
+++ b/ActionUI/ActionUI.Plugin/HotbarsStartup.cs
@@ -34,8 +34,6 @@ namespace ModifAmorphic.Outward.ActionUI
 
             _harmony.PatchAll(typeof(InputManager_BasePatches));
             _harmony.PatchAll(typeof(RewiredInputsPatches));
-            _harmony.PatchAll(typeof(CharacterUIPatches));
-            _harmony.PatchAll(typeof(QuickSlotControllerSwitcherPatches));
             _harmony.PatchAll(typeof(QuickSlotPanelPatches));
             _harmony.PatchAll(typeof(ControlsInputPatches));
             _harmony.PatchAll(typeof(CharacterQuickSlotManagerPatches));

--- a/ActionUI/ActionUI.Plugin/InventoryStartup.cs
+++ b/ActionUI/ActionUI.Plugin/InventoryStartup.cs
@@ -34,13 +34,11 @@ namespace ModifAmorphic.Outward.ActionUI
             _harmony.PatchAll(typeof(EquipmentMenuPatches));
             _harmony.PatchAll(typeof(InventoryContentDisplayPatches));
             _harmony.PatchAll(typeof(ItemDisplayPatches));
-            _harmony.PatchAll(typeof(NetworkLevelLoaderPatches));
             _harmony.PatchAll(typeof(NetworkInstantiateManagerPatches));
 
             _services
                      .AddSingleton(new InventoryServicesInjector(_services, _playerMenuService, _coroutines, _loggerFactory))
                      .AddSingleton(new EquipSetPrefabService(_services.GetService<InventoryServicesInjector>(), _coroutines, _loggerFactory));
-
         }
     }
 }

--- a/ActionUI/ActionUI.Plugin/Models/SkillSlotAction.cs
+++ b/ActionUI/ActionUI.Plugin/Models/SkillSlotAction.cs
@@ -1,152 +1,33 @@
 ﻿using ModifAmorphic.Outward.ActionUI.Services;
-using ModifAmorphic.Outward.Extensions;
 using ModifAmorphic.Outward.Logging;
 using ModifAmorphic.Outward.Unity.ActionMenus;
-using ModifAmorphic.Outward.Unity.ActionUI;
 using Rewired;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using UnityEngine.UI;
 
 namespace ModifAmorphic.Outward.ActionUI.Models
 {
-    internal class SkillSlotAction : ISlotAction, IOutwardItem
+    internal class SkillSlotAction : SlotActionBase
     {
-        private readonly Player player;
-        private readonly Character character;
-        private readonly CharacterInventory inventory;
-        private readonly SlotDataService slotData;
-
-        private ActionConfig actionConfig;
-
         private Skill skill;
         public Skill ActionSkill => skill;
-        public Item ActionItem => skill;
 
-        private readonly int itemId;
-        public int ActionId => itemId;
-
-        private string itemUid;
-        public string ActionUid => itemUid;
-
-        private int hotbarIndex;
-        private int slotIndex;
-
-        private IModifLogger Logger => _getLogger.Invoke();
-        private readonly Func<IModifLogger> _getLogger;
-
-        public bool IsEditable { get; internal set; }
-
-        public string DisplayName { get; internal set; }
-
-        public ICooldown Cooldown { get; internal set; }
-
-        public IStackable Stack => null;
-
-        public Dictionary<BarPositions, IBarProgress> ActiveBars => null;
-
-        public ActionSlotIcon[] ActionIcons { get; internal set; }
-
-        public bool HasDynamicIcon { get; internal set; }
-
-        public bool IsCombatModeEnabled { get; private set; }
-
-        public event Action OnActionRequested;
-        public event Action OnEditRequested;
-        public event Action<ActionSlotIcon[]> OnIconsChanged;
-
-        public Action TargetAction => TryActivateTarget;
-
-        public bool CheckOnUpdate { get; internal set; } = true;
+        private readonly bool isEquipmentSetSkill;
+        private EquipmentSetSkill equipmentSetSkill;
 
         public SkillSlotAction(Skill skill, Player player, Character character, SlotDataService slotData, bool combatModeEnabled, Func<IModifLogger> getLogger)
+            : base(skill, player, character, slotData, combatModeEnabled, getLogger)
         {
-            (this.skill, this.player, this.character, this.slotData, _getLogger) = (skill, player, character, slotData, getLogger);
+            this.skill = skill;
 
-            this.inventory = character.Inventory;
-            this.ActionIcons = GetSkillSprites(false);
-            this.DisplayName = skill.DisplayName;
-            this.HasDynamicIcon = skill.HasDynamicQuickSlotIcon || skill is EquipmentSetSkill;
-            this.IsCombatModeEnabled = combatModeEnabled;
             this.Cooldown = new ItemCooldownTracker(skill);
+            this.Stack = null;
+            this.equipmentSetSkill = skill as EquipmentSetSkill;
+            this.isEquipmentSetSkill = equipmentSetSkill != null;
 
-            itemId = skill.ItemID;
-            itemUid = skill.UID;
         }
 
-
-        public ActionSlotIcon[] GetDynamicIcons()
-        {
-            bool isLocked = !skill.IsChildToCharacter || !skill.GetIsQuickSlotReq();
-
-            return GetSkillSprites(isLocked);
-        }
-        private static HashSet<string> ignored = new HashSet<string>()
-        {
-            "Icon", "border", "break", "background", "Dot", "Background", "Fill", "imgNew", "imgHighlight", "Backbround", "CoinIcon"
-        };
-        private ActionSlotIcon[] GetSkillSprites(bool isLocked)
-        {
-            var actionIcon = isLocked ? skill.LockedIcon ?? skill.QuickSlotIcon ?? skill.ItemIcon : skill.QuickSlotIcon;
-
-            var itemDisplay = skill.GetPrivateField<Item, ItemDisplay>("m_refItemDisplay");
-            var sprites = new List<ActionSlotIcon>()
-            {
-                new ActionSlotIcon() { Name = actionIcon.name, Icon = actionIcon }
-            };
-
-            if (itemDisplay != null)
-            {
-                for (int i = 0; i < itemDisplay.transform.childCount; i++)
-                {
-                    var child = itemDisplay.transform.GetChild(i);
-                    var image = child.GetComponent<Image>();
-
-                    if (image != null && image.gameObject.activeSelf && !ignored.Contains(image.name) && (image.sprite != null || image.overrideSprite != null))
-                        sprites.Add(new ActionSlotIcon() { Name = image.name, Icon = image.overrideSprite ?? image.sprite });
-                }
-            }
-
-            return sprites.ToArray();
-        }
-
-        public bool GetIsActionRequested()
-        {
-            return !IsEditable && player.GetButtonDown(actionConfig.RewiredActionId) && GetEnabled();
-        }
-        public bool GetIsEditRequested()
-        {
-            return IsEditable && player.GetButtonDown(actionConfig.RewiredActionId);
-        }
-
-        private void TryActivateTarget()
-        {
-            try
-            {
-                ActivateTarget();
-            }
-            catch (Exception ex)
-            {
-                Logger.LogException($"Failed to activate {actionConfig.RewiredActionName} item/skill {skill?.name} for character {character?.name}", ex);
-            }
-        }
-        public void ActivateTarget()
-        {
-            if (this.skill == null)
-                return;
-
-            if (inventory.LearnedSkill(skill))
-            {
-                skill.TryQuickSlotUse();
-            }
-            else
-            {
-                character.CharacterUI.ShowInfoNotification(LocalizationManager.Instance.GetLoc("Notification_Quickslot_NoItemInventory", Global.SetTextColor(skill.Name, Global.HIGHLIGHT)));
-            }
-        }
-
-        public bool GetEnabled()
+        public override bool GetEnabled()
         {
             if (IsCombatModeEnabled && character.InCombat && (hotbarIndex != 0 || slotIndex > 7))
                 return false;
@@ -168,16 +49,30 @@ namespace ModifAmorphic.Outward.ActionUI.Models
             return false;
         }
 
-        public void SlotActionAssigned(ActionSlot assignedSlot)
+        public override void ActivateTarget()
         {
-            hotbarIndex = assignedSlot.HotbarIndex;
-            slotIndex = assignedSlot.SlotIndex;
-            skill.SetQuickSlot(0);
-            actionConfig = (ActionConfig)assignedSlot.Config;
+            if (this.skill == null)
+                return;
+
+            if (inventory.LearnedSkill(skill))
+            {
+                skill.TryQuickSlotUse();
+            }
+            else
+            {
+                character.CharacterUI.ShowInfoNotification(LocalizationManager.Instance.GetLoc("Notification_Quickslot_NoItemInventory", Global.SetTextColor(skill.Name, Global.HIGHLIGHT)));
+            }
         }
-        public void SlotActionUnassigned()
+
+        protected override bool GetIsLocked() => !skill.IsChildToCharacter || !skill.GetIsQuickSlotReq();
+
+        protected override void AssignRefItemDisplay(ActionSlot assignedSlot)
         {
-            skill.SetQuickSlot(-1);
+            base.AssignRefItemDisplay(assignedSlot);
+            if (isEquipmentSetSkill && refItemDisplay != null)
+            {
+                EquipSetPrefabService.Instance.AddEquipmentSetIcon(refItemDisplay, equipmentSetSkill);
+            }
         }
     }
 }

--- a/ActionUI/ActionUI.Plugin/Models/SlotActionBase.cs
+++ b/ActionUI/ActionUI.Plugin/Models/SlotActionBase.cs
@@ -1,0 +1,174 @@
+﻿using ModifAmorphic.Outward.ActionUI.Extensions;
+using ModifAmorphic.Outward.ActionUI.Services;
+using ModifAmorphic.Outward.Extensions;
+using ModifAmorphic.Outward.Logging;
+using ModifAmorphic.Outward.Unity.ActionMenus;
+using ModifAmorphic.Outward.Unity.ActionUI;
+using Rewired;
+using System;
+using System.Collections.Generic;
+using UnityEngine.UI;
+
+namespace ModifAmorphic.Outward.ActionUI.Models
+{
+    internal abstract class SlotActionBase : ISlotAction, IOutwardItem
+    {
+        protected readonly Player player;
+        protected readonly Character character;
+        protected readonly CharacterInventory inventory;
+        protected readonly SlotDataService slotData;
+
+        protected readonly int itemId;
+
+        protected readonly Dictionary<BarPositions, IBarProgress> _activeBars = new Dictionary<BarPositions, IBarProgress>();
+
+        protected string itemUid;
+
+        protected int hotbarIndex;
+        protected int slotIndex;
+
+        protected ItemDisplay refItemDisplay;
+
+        protected ActionConfig actionConfig;
+
+        protected Item actionItem;
+        public Item ActionItem => actionItem;
+        public int ActionId => itemId;
+        public string ActionUid => itemUid;
+
+        public bool IsEditable { get; internal set; }
+
+        public string DisplayName { get; internal set; }
+
+        public ICooldown Cooldown { get; internal set; }
+
+        public IStackable Stack { get; internal set; }
+        public Dictionary<BarPositions, IBarProgress> ActiveBars => _activeBars;
+
+        public ActionSlotIcon[] ActionIcons { get; internal set; }
+
+        public bool HasDynamicIcon { get; internal set; }
+
+        public bool IsCombatModeEnabled { get; private set; }
+
+        public Action TargetAction => TryActivateTarget;
+
+        public bool CheckOnUpdate { get; internal set; } = true;
+
+        private readonly Func<IModifLogger> _getLogger;
+        protected IModifLogger Logger => _getLogger.Invoke();
+
+        public event Action OnActionRequested;
+        public event Action OnEditRequested;
+        public event Action<ActionSlotIcon[]> OnIconsChanged;
+
+
+        public SlotActionBase(Item item, Player player, Character character, SlotDataService slotData, bool combatModeEnabled, Func<IModifLogger> getLogger)
+        {
+            (this.actionItem, this.player, this.character, this.slotData, _getLogger) = (item, player, character, slotData, getLogger);
+
+            this.inventory = character.Inventory;
+            this.ActionIcons = GetActionIcons(false).ToArray();
+            this.DisplayName = item.DisplayName;
+            this.HasDynamicIcon = item.HasDynamicQuickSlotIcon;
+            this.IsCombatModeEnabled = combatModeEnabled;
+            this.Stack = item.IsStackable() ? new StackTracker(this, character.Inventory) : null;
+
+            itemId = item.ItemID;
+            itemUid = item.UID;
+        }
+
+        public abstract void ActivateTarget();
+
+        public ActionSlotIcon[] GetDynamicIcons() => GetActionIcons(GetIsLocked()).ToArray();
+
+        public abstract bool GetEnabled();
+
+        public bool GetIsActionRequested() => !IsEditable && player.GetButtonDown(actionConfig.RewiredActionId);
+
+        public bool GetIsEditRequested() => IsEditable && player.GetButtonDown(actionConfig.RewiredActionId);
+
+        public void SlotActionAssigned(ActionSlot assignedSlot)
+        {
+            hotbarIndex = assignedSlot.HotbarIndex;
+            slotIndex = assignedSlot.SlotIndex;
+            actionItem.SetQuickSlot(0);
+            actionConfig = (ActionConfig)assignedSlot.Config;
+
+            if (refItemDisplay != null)
+                refItemDisplay.gameObject.Destroy();
+
+            AssignRefItemDisplay(assignedSlot);
+            this.OnIconsChanged?.Invoke(GetActionIcons(false).ToArray());
+        }
+
+        protected virtual void AssignRefItemDisplay(ActionSlot assignedSlot)
+        {
+            if (UIUtilities.ItemDisplayPrefab != null)
+            {
+                refItemDisplay = UnityEngine.Object.Instantiate<ItemDisplay>(UIUtilities.ItemDisplayPrefab);
+                refItemDisplay.transform.SetParent(assignedSlot.ActionImages.transform);
+                refItemDisplay.transform.SetAsLastSibling();
+                refItemDisplay.transform.ResetLocal();
+                refItemDisplay.SetReferencedItem(this.actionItem);
+                refItemDisplay.gameObject.SetActive(false);
+            }
+        }
+
+        protected void RaiseOnActionRequested() => OnActionRequested?.Invoke();
+        protected void RaiseOnEditRequested() => OnEditRequested?.Invoke();
+        protected void RaiseOnIconsChanged() => OnIconsChanged?.Invoke(GetActionIcons(GetIsLocked()).ToArray());
+
+        protected abstract bool GetIsLocked();
+
+        public virtual void SlotActionUnassigned()
+        {
+            actionItem.SetQuickSlot(-1);
+        }
+
+        private static HashSet<string> ignoredIcons = new HashSet<string>()
+        {
+            "Icon", "border", "break", "background", "Dot", "Background", "Fill", "imgNew", "imgHighlight", "Backbround", "CoinIcon"
+        };
+
+        protected virtual List<ActionSlotIcon> GetActionIcons(bool isLocked)
+        {
+            var actionIcon = isLocked ? actionItem.LockedIcon ?? actionItem.QuickSlotIcon ?? actionItem.ItemIcon : actionItem.QuickSlotIcon;
+
+            var itemDisplay = actionItem.GetPrivateField<Item, ItemDisplay>("m_refItemDisplay");
+            var sprites = new List<ActionSlotIcon>()
+            {
+                new ActionSlotIcon() { Name = actionIcon.name, Icon = actionIcon }
+            };
+
+            if (itemDisplay != null)
+            {
+                for (int i = 0; i < itemDisplay.transform.childCount; i++)
+                {
+                    var child = itemDisplay.transform.GetChild(i);
+                    var image = child.GetComponent<Image>();
+
+                    if (image != null && image.gameObject.activeSelf && !ignoredIcons.Contains(image.name) && (image.sprite != null || image.overrideSprite != null))
+                        sprites.Add(new ActionSlotIcon() { Name = image.name, Icon = image.overrideSprite ?? image.sprite });
+                }
+            }
+#if DEBUG
+            //Logger.LogTrace($"SlotIndex: {slotIndex}. Got {sprites.Count} Sprites.");
+#endif
+
+            return sprites;
+        }
+
+        private void TryActivateTarget()
+        {
+            try
+            {
+                ActivateTarget();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException($"Failed to activate {actionConfig.RewiredActionName} item/skill {actionItem?.name} for character {character?.name}", ex);
+            }
+        }
+    }
+}

--- a/ActionUI/ActionUI.Plugin/Patches/CharacterInventoryPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/CharacterInventoryPatches.cs
@@ -21,6 +21,9 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
+                if (___m_character == null || ___m_character?.OwnerPlayerSys == null || !___m_character.IsLocalPlayer)
+                    return;
+
                 Logger.LogTrace($"{nameof(CharacterInventoryPatches)}::{nameof(InventoryIngredientsPostFix)}(): Invoking {nameof(AfterInventoryIngredients)}.");
                 AfterInventoryIngredients?.Invoke(__instance, ___m_character, _craftingStationTag, ref _sortedIngredient);
             }
@@ -40,7 +43,7 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
-                if (__result == true || ___m_character?.OwnerPlayerSys == null)
+                if (__result == true || ___m_character?.OwnerPlayerSys == null || !___m_character.IsLocalPlayer)
                     return;
 
                 var playerId = ___m_character.OwnerPlayerSys.PlayerID;
@@ -48,11 +51,11 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
                 if (OwnsItemDelegates.TryGetValue(playerId, out var ownsItem))
                 {
                     //Called on Update. Spams logs
-                    Logger.LogDebug($"{nameof(CharacterInventoryPatches)}::{nameof(OwnsItemPostFix)}(): Invoked for PlayerID {playerId}. Invoking {nameof(OwnsItemDelegates)} delegate.");
+                    //Logger.LogDebug($"{nameof(CharacterInventoryPatches)}::{nameof(OwnsItemPostFix)}(): Invoked for PlayerID {playerId}. Invoking {nameof(OwnsItemDelegates)} delegate.");
 
                     __result = ownsItem(_itemUID);
-                    if (__result)
-                        Logger.LogDebug($"Found item with UID '{_itemUID}' in stash.");
+                    //if (__result)
+                    //    Logger.LogDebug($"Found item with UID '{_itemUID}' in stash.");
                 }
             }
             catch (Exception ex)

--- a/ActionUI/ActionUI.Plugin/Patches/CharacterInventoryPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/CharacterInventoryPatches.cs
@@ -48,8 +48,11 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
                 if (OwnsItemDelegates.TryGetValue(playerId, out var ownsItem))
                 {
                     //Called on Update. Spams logs
-                    //Logger.LogTrace($"{nameof(CharacterInventoryPatches)}::{nameof(OwnsItemPostFix)}(): Invoked for PlayerID {playerId}. Invoking {nameof(OwnsItemDelegates)} delegate.");
+                    Logger.LogDebug($"{nameof(CharacterInventoryPatches)}::{nameof(OwnsItemPostFix)}(): Invoked for PlayerID {playerId}. Invoking {nameof(OwnsItemDelegates)} delegate.");
+
                     __result = ownsItem(_itemUID);
+                    if (__result)
+                        Logger.LogDebug($"Found item with UID '{_itemUID}' in stash.");
                 }
             }
             catch (Exception ex)

--- a/ActionUI/ActionUI.Plugin/Patches/CharacterQuickSlotManagerPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/CharacterQuickSlotManagerPatches.cs
@@ -21,6 +21,9 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
+                if (___m_character == null || ___m_character?.OwnerPlayerSys == null || !___m_character.IsLocalPlayer)
+                    return true;
+
                 Logger.LogTrace($"{nameof(CharacterQuickSlotManagerPatches)}::{nameof(ItemDestroyedPrefix)}(): Invoked for PlayerID {___m_character?.OwnerPlayerSys?.PlayerID}.");
                 if (___m_character?.OwnerPlayerSys != null)
                 {

--- a/ActionUI/ActionUI.Plugin/Patches/EquipmentMenuPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/EquipmentMenuPatches.cs
@@ -17,6 +17,9 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
+                if (__instance.LocalCharacter == null || __instance.LocalCharacter.OwnerPlayerSys == null || !__instance.LocalCharacter.IsLocalPlayer)
+                    return;
+
                 Logger.LogTrace($"{nameof(EquipmentMenuPatches)}::{nameof(ShowPostfix)}(): Invoking {nameof(AfterShow)} for character {__instance.LocalCharacter?.UID}.");
                 AfterShow?.Invoke(__instance);
             }
@@ -34,6 +37,9 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
+                if (__instance.LocalCharacter == null || __instance.LocalCharacter.OwnerPlayerSys == null || !__instance.LocalCharacter.IsLocalPlayer)
+                    return;
+
                 Logger.LogTrace($"{nameof(EquipmentMenuPatches)}::{nameof(OnHidePostfix)}(): Invoking {nameof(AfterOnHide)} for character {__instance.LocalCharacter?.UID}.");
                 AfterOnHide?.Invoke(__instance);
             }

--- a/ActionUI/ActionUI.Plugin/Patches/EquipmentPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/EquipmentPatches.cs
@@ -19,7 +19,7 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
-                if (!_char.IsLocalPlayer)
+                if (_char == null || _char.OwnerPlayerSys == null || !_char.IsLocalPlayer)
                     return;
 
                 Logger.LogTrace($"{nameof(EquipmentPatches)}::{nameof(OnEquipPostfix)}(): Invoked. Equipped item '{__instance.name}' to slot '{__instance.CurrentEquipmentSlot?.SlotType}' for character {_char?.name}. Invoking {nameof(AfterOnEquip)}.");
@@ -41,7 +41,7 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
-                if (!_char.IsLocalPlayer)
+                if (_char == null || _char.OwnerPlayerSys == null || !_char.IsLocalPlayer)
                     return;
 
                 Logger.LogTrace($"{nameof(EquipmentPatches)}::{nameof(OnUnequipPostfix)}(): Invoked. Unequipped item '{__instance.name}' from slot '{__instance.CurrentEquipmentSlot?.SlotType}' for character {_char?.name}. Invoking {nameof(AfterOnUnequip)}.");

--- a/ActionUI/ActionUI.Plugin/Patches/InventoryContentDisplayPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/InventoryContentDisplayPatches.cs
@@ -9,22 +9,65 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
     {
         private static IModifLogger Logger => LoggerFactory.GetLogger(ModInfo.ModId);
 
-        public static event Action<InventoryContentDisplay> AfterStartInit;
+        //public static event Action<InventoryContentDisplay> BeforeShow;
 
-        [HarmonyPatch("StartInit")]
-        [HarmonyPostfix]
-        private static void StartInitPostfix(InventoryContentDisplay __instance)
-        {
-            try
-            {
-                Logger.LogTrace($"{nameof(InventoryContentDisplay)}::{nameof(StartInitPostfix)}(): Invoking {nameof(AfterStartInit)}.");
-                AfterStartInit?.Invoke(__instance);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogException($"{nameof(InventoryContentDisplay)}::{nameof(StartInitPostfix)}(): Exception invoking {nameof(AfterStartInit)}.", ex);
-            }
-        }
+        //[HarmonyPatch(nameof(InventoryContentDisplay.Show))]
+        //[HarmonyPrefix]
+        //private static void ShowPrefix(InventoryContentDisplay __instance)
+        //{
+        //    try
+        //    {
+        //        if (__instance.LocalCharacter == null || __instance.LocalCharacter.OwnerPlayerSys == null || !__instance.LocalCharacter.IsLocalPlayer)
+        //            return;
+
+        //        Logger.LogDebug($"{nameof(InventoryContentDisplay)}::{nameof(ShowPrefix)}(): Invoking {nameof(BeforeShow)}.");
+        //        BeforeShow?.Invoke(__instance);
+        //    }
+        //    catch (Exception ex)
+        //    {
+        //        Logger.LogException($"{nameof(InventoryContentDisplay)}::{nameof(ShowPrefix)}(): Exception invoking {nameof(BeforeShow)}.", ex);
+        //    }
+        //}
+
+        //public static event Action<InventoryContentDisplay> AfterDelayedFocus;
+
+        //[HarmonyPatch("DelayedFocus")]
+        //[HarmonyPostfix]
+        //private static void DelayedFocusPostfix(InventoryContentDisplay __instance)
+        //{
+        //    try
+        //    {
+        //        if (__instance.LocalCharacter == null || __instance.LocalCharacter.OwnerPlayerSys == null || !__instance.LocalCharacter.IsLocalPlayer)
+        //            return;
+
+        //        Logger.LogDebug($"{nameof(InventoryContentDisplay)}::{nameof(DelayedFocusPostfix)}(): Invoking {nameof(AfterDelayedFocus)}.");
+        //        AfterDelayedFocus?.Invoke(__instance);
+        //    }
+        //    catch (Exception ex)
+        //    {
+        //        Logger.LogException($"{nameof(InventoryContentDisplay)}::{nameof(DelayedFocusPostfix)}(): Exception invoking {nameof(AfterDelayedFocus)}.", ex);
+        //    }
+        //}
+
+        //public static event Action<InventoryContentDisplay> AfterStartInit;
+
+        //[HarmonyPatch("StartInit")]
+        //[HarmonyPostfix]
+        //private static void StartInitPostfix(InventoryContentDisplay __instance)
+        //{
+        //    try
+        //    {
+        //        if (__instance.LocalCharacter == null || __instance.LocalCharacter.OwnerPlayerSys == null || !__instance.LocalCharacter.IsLocalPlayer)
+        //            return;
+
+        //        Logger.LogDebug($"{nameof(InventoryContentDisplay)}::{nameof(StartInitPostfix)}(): Invoking {nameof(AfterStartInit)}.");
+        //        AfterStartInit?.Invoke(__instance);
+        //    }
+        //    catch (Exception ex)
+        //    {
+        //        Logger.LogException($"{nameof(InventoryContentDisplay)}::{nameof(StartInitPostfix)}(): Exception invoking {nameof(AfterStartInit)}.", ex);
+        //    }
+        //}
 
         public static event Action<InventoryContentDisplay> AfterOnHide;
 
@@ -34,7 +77,10 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
-                Logger.LogTrace($"{nameof(InventoryContentDisplay)}::{nameof(OnHidePostfix)}(): Invoking {nameof(AfterOnHide)}.");
+                if (__instance.LocalCharacter == null || __instance.LocalCharacter.OwnerPlayerSys == null || !__instance.LocalCharacter.IsLocalPlayer)
+                    return;
+
+                Logger.LogDebug($"{nameof(InventoryContentDisplay)}::{nameof(OnHidePostfix)}(): Invoking {nameof(AfterOnHide)}.");
                 AfterOnHide?.Invoke(__instance);
             }
             catch (Exception ex)
@@ -72,7 +118,7 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
-                Logger.LogTrace($"{nameof(InventoryContentDisplay)}::{nameof(SetContainersVisibilityPostfix)}(): Invoking {nameof(AfterSetContainersVisibility)}.");
+                Logger.LogDebug($"{nameof(InventoryContentDisplay)}::{nameof(SetContainersVisibilityPostfix)}(): Invoking {nameof(AfterSetContainersVisibility)}.");
                 AfterSetContainersVisibility?.Invoke(__instance, _showPouch, _showBag, _showEquipment);
             }
             catch (Exception ex)
@@ -91,7 +137,7 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
-                Logger.LogTrace($"{nameof(InventoryContentDisplay)}::{nameof(RefreshReferencesPostfix)}(): Invoking {nameof(AfterRefreshReferences)}.");
+                Logger.LogDebug($"{nameof(InventoryContentDisplay)}::{nameof(RefreshReferencesPostfix)}(): Invoking {nameof(AfterRefreshReferences)}.");
                 AfterRefreshReferences?.Invoke(__instance, _forceRefresh);
             }
             catch (Exception ex)
@@ -111,7 +157,7 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
-                Logger.LogTrace($"{nameof(InventoryContentDisplay)}::{nameof(RefreshContainerDisplaysPostfix)}(): Invoking {nameof(AfterRefreshContainerDisplays)}.");
+                Logger.LogDebug($"{nameof(InventoryContentDisplay)}::{nameof(RefreshContainerDisplaysPostfix)}(): Invoking {nameof(AfterRefreshContainerDisplays)}.");
                 AfterRefreshContainerDisplays?.Invoke(__instance, _clearAssignedDisplay);
             }
             catch (Exception ex)

--- a/ActionUI/ActionUI.Plugin/Patches/ItemDisplayDropGroundPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/ItemDisplayDropGroundPatches.cs
@@ -20,15 +20,17 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
-                if (___m_draggedDisplay?.LocalCharacter?.OwnerPlayerSys != null)
+                if (___m_draggedDisplay?.LocalCharacter == null || ___m_draggedDisplay.LocalCharacter.OwnerPlayerSys == null || !___m_draggedDisplay.LocalCharacter.IsLocalPlayer)
+                    return;
+
+
+                var playerId = ___m_draggedDisplay.LocalCharacter.OwnerPlayerSys.PlayerID;
+                if (TryGetIsDropValids.TryGetValue(playerId, out var tryIsDropValid))
                 {
-                    var playerId = ___m_draggedDisplay.LocalCharacter.OwnerPlayerSys.PlayerID;
-                    if (TryGetIsDropValids.TryGetValue(playerId, out var tryIsDropValid))
-                    {
-                        if (tryIsDropValid(___m_draggedDisplay, ___m_draggedDisplay.LocalCharacter, out var result))
-                            __result = result;
-                    }
+                    if (tryIsDropValid(___m_draggedDisplay, ___m_draggedDisplay.LocalCharacter, out var result))
+                        __result = result;
                 }
+
             }
             catch (Exception ex)
             {

--- a/ActionUI/ActionUI.Plugin/Patches/ItemDisplayPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/ItemDisplayPatches.cs
@@ -22,6 +22,9 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
                 if (_item == null)
                     return;
 
+                if (__instance?.LocalCharacter == null || __instance.LocalCharacter.OwnerPlayerSys == null || !__instance.LocalCharacter.IsLocalPlayer)
+                    return;
+
                 Logger.LogTrace($"{nameof(ItemDisplayPatches)}::{nameof(SetReferencedItemPostfix)}(): Invoking {nameof(AfterSetReferencedItem)} for Item {_item.name}.");
                 AfterSetReferencedItem?.Invoke(__instance, _item);
             }

--- a/ActionUI/ActionUI.Plugin/Patches/QuickSlotPanelPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/QuickSlotPanelPatches.cs
@@ -16,6 +16,9 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
+                if (__instance?.LocalCharacter == null || __instance.LocalCharacter.OwnerPlayerSys == null || !__instance.LocalCharacter.IsLocalPlayer)
+                    return;
+
                 if (__instance is KeyboardQuickSlotPanel keyboard)
                 {
                     Logger.LogTrace($"{nameof(QuickSlotPanelPatches)}::{nameof(StartInitPostfix)}(): Invoked. Invoking {nameof(StartInitAfter)}({nameof(KeyboardQuickSlotPanel)}).");

--- a/ActionUI/ActionUI.Plugin/Patches/RewiredInputsPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/RewiredInputsPatches.cs
@@ -1,7 +1,6 @@
 ﻿using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using System;
-using System.Collections.Generic;
 
 namespace ModifAmorphic.Outward.ActionUI.Patches
 {

--- a/ActionUI/ActionUI.Plugin/Patches/Sandbox/CharacterEquipmentPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/Sandbox/CharacterEquipmentPatches.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿#if DEBUG
+using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using System;
 
@@ -32,3 +33,4 @@ namespace ModifAmorphic.Outward.ActionUI.Patches.Sandbox
         }
     }
 }
+#endif

--- a/ActionUI/ActionUI.Plugin/Patches/Sandbox/CharacterManagerPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/Sandbox/CharacterManagerPatches.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿#if DEBUG
+using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using System;
 
@@ -28,3 +29,4 @@ namespace ModifAmorphic.Outward.ActionUI.Patches.Sandbox
         }
     }
 }
+#endif

--- a/ActionUI/ActionUI.Plugin/Patches/Sandbox/CharacterPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/Sandbox/CharacterPatches.cs
@@ -1,7 +1,7 @@
-﻿using HarmonyLib;
+﻿#if DEBUG
+using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using System;
-using System.Collections.Generic;
 
 namespace ModifAmorphic.Outward.ActionUI.Patches
 {
@@ -14,7 +14,7 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         public static event Action<Character> AfterApplyQuicklots;
 
         [HarmonyPatch(nameof(Character.ApplyQuicklots), MethodType.Normal)]
-        [HarmonyPatch(new Type[] { typeof(PlayerSaveData) }) ]
+        [HarmonyPatch(new Type[] { typeof(PlayerSaveData) })]
         [HarmonyPostfix]
         private static void ApplyQuicklotsPostFix(Character __instance, PlayerSaveData _save)
         {
@@ -30,3 +30,4 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         }
     }
 }
+#endif

--- a/ActionUI/ActionUI.Plugin/Patches/Sandbox/CharacterSavePatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/Sandbox/CharacterSavePatches.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿#if DEBUG
+using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using System;
 
@@ -28,3 +29,4 @@ namespace ModifAmorphic.Outward.ActionUI.Patches.Sandbox
         }
     }
 }
+#endif

--- a/ActionUI/ActionUI.Plugin/Patches/Sandbox/ItemDisplayDropPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/Sandbox/ItemDisplayDropPatches.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿#if DEBUG
+using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using System;
 using UnityEngine.EventSystems;
@@ -29,3 +30,4 @@ namespace ModifAmorphic.Outward.ActionUI.Patches.Sandbox
         }
     }
 }
+#endif

--- a/ActionUI/ActionUI.Plugin/Patches/Sandbox/MapHelperPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/Sandbox/MapHelperPatches.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿#if DEBUG
+using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using Rewired;
 using System;
@@ -68,3 +69,4 @@ namespace ModifAmorphic.Outward.ActionUI.Patches.Sandbox
         }
     }
 }
+#endif

--- a/ActionUI/ActionUI.Plugin/Patches/Sandbox/MenuManagerPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/Sandbox/MenuManagerPatches.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿#if DEBUG
+using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using System;
 
@@ -27,7 +28,7 @@ namespace ModifAmorphic.Outward.ActionUI.Patches.Sandbox
 
         //public delegate bool GetIsApplicationFocused(MenuManager __instance);
         //public static GetIsApplicationFocused GetIsApplicationFocusedCallback;
-        public static Func<bool> GetIsApplicationFocused;
+        public static event Func<bool> GetIsApplicationFocused;
         //public static event GetIsApplicationFocused OnIsApplicationFocused;
         [HarmonyPatch("IsApplicationFocused", MethodType.Getter)]
         [HarmonyPostfix]
@@ -45,3 +46,4 @@ namespace ModifAmorphic.Outward.ActionUI.Patches.Sandbox
         }
     }
 }
+#endif

--- a/ActionUI/ActionUI.Plugin/Patches/Sandbox/NetworkLevelLoaderPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/Sandbox/NetworkLevelLoaderPatches.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿#if DEBUG
+using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using System;
 
@@ -27,3 +28,4 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
 
     }
 }
+#endif

--- a/ActionUI/ActionUI.Plugin/Patches/Sandbox/QuickSlotControllerSwitcherPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/Sandbox/QuickSlotControllerSwitcherPatches.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿#if DEBUG
+using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using System;
 
@@ -17,6 +18,9 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
+                if (__instance?.LocalCharacter == null || __instance.LocalCharacter.OwnerPlayerSys == null || !__instance.LocalCharacter.IsLocalPlayer)
+                    return;
+
                 Logger.LogTrace($"{nameof(QuickSlotControllerSwitcherPatches)}::{nameof(StartInitPostfix)}(): Invoked. Invoking {nameof(StartInitAfter)}({nameof(KeyboardQuickSlotPanel)}).");
                 StartInitAfter?.Invoke(__instance);
             }
@@ -27,3 +31,4 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         }
     }
 }
+#endif

--- a/ActionUI/ActionUI.Plugin/Patches/Sandbox/UserDataPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/Sandbox/UserDataPatches.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿#if DEBUG
+using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using Rewired;
 using Rewired.Data;
@@ -110,3 +111,4 @@ namespace ModifAmorphic.Outward.ActionUI.Patches.Sandbox
         }
     }
 }
+#endif

--- a/ActionUI/ActionUI.Plugin/Patches/Sandbox/UserDataStore_PlayerPrefsPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/Sandbox/UserDataStore_PlayerPrefsPatches.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿#if DEBUG
+using HarmonyLib;
 using ModifAmorphic.Outward.Logging;
 using Rewired.Data;
 using System;
@@ -27,3 +28,4 @@ namespace ModifAmorphic.Outward.ActionUI.Patches.Sandbox
         }
     }
 }
+#endif

--- a/ActionUI/ActionUI.Plugin/Patches/SkillMenuPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/SkillMenuPatches.cs
@@ -18,6 +18,9 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
+                if (___m_skillList?.LocalCharacter == null || ___m_skillList.LocalCharacter.OwnerPlayerSys == null || !___m_skillList.LocalCharacter.IsLocalPlayer)
+                    return;
+
                 Logger.LogTrace($"{nameof(SkillMenuPatches)}::{nameof(OnSectionSelectedPostfix)}(): Invoked. Invoking {nameof(AfterOnSectionSelected)}.");
                 AfterOnSectionSelected?.Invoke(___m_skillList);
             }

--- a/ActionUI/ActionUI.Plugin/Patches/SplitPlayerPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/SplitPlayerPatches.cs
@@ -9,21 +9,24 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
     {
         private static IModifLogger Logger => LoggerFactory.GetLogger(ModInfo.ModId);
 
-        public static event Action<SplitPlayer> InitAfter;
-        [HarmonyPatch(nameof(SplitPlayer.Init))]
-        [HarmonyPostfix]
-        private static void InitPostfix(SplitPlayer __instance)
-        {
-            try
-            {
-                Logger.LogTrace($"{nameof(SplitPlayerPatches)}::{nameof(InitPostfix)}(): Invoked. Invoking {nameof(InitAfter)}({nameof(SplitPlayer)}).");
-                InitAfter?.Invoke(__instance);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogException($"{nameof(SplitPlayerPatches)}::{nameof(InitPostfix)}(): Exception Invoking {nameof(InitAfter)}({nameof(SplitPlayer)}).", ex);
-            }
-        }
+        //public static event Action<SplitPlayer> InitAfter;
+        //[HarmonyPatch(nameof(SplitPlayer.Init))]
+        //[HarmonyPostfix]
+        //private static void InitPostfix(SplitPlayer __instance)
+        //{
+        //    try
+        //    {
+        //        if (__instance?.AssignedCharacter == null || __instance.AssignedCharacter.OwnerPlayerSys == null || !__instance.AssignedCharacter.IsLocalPlayer)
+        //            return;
+
+        //        Logger.LogTrace($"{nameof(SplitPlayerPatches)}::{nameof(InitPostfix)}(): Invoked. Invoking {nameof(InitAfter)}({nameof(SplitPlayer)}).");
+        //        InitAfter?.Invoke(__instance);
+        //    }
+        //    catch (Exception ex)
+        //    {
+        //        Logger.LogException($"{nameof(SplitPlayerPatches)}::{nameof(InitPostfix)}(): Exception Invoking {nameof(InitAfter)}({nameof(SplitPlayer)}).", ex);
+        //    }
+        //}
 
         public delegate void SetCharacter(SplitPlayer splitPlayer, Character character);
         public static event SetCharacter SetCharacterAfter;
@@ -34,6 +37,9 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
+                if (__instance?.AssignedCharacter == null || __instance.AssignedCharacter.OwnerPlayerSys == null || !__instance.AssignedCharacter.IsLocalPlayer)
+                    return;
+
                 Logger.LogTrace($"{nameof(SplitPlayerPatches)}::{nameof(SetCharacterPostfix)}(): Invoked. Invoking {nameof(SetCharacterAfter)}({nameof(SplitPlayer)}, {nameof(Character)}).");
                 SetCharacterAfter?.Invoke(__instance, _character);
             }

--- a/ActionUI/ActionUI.Plugin/Patches/SplitScreenManagerPatches.cs
+++ b/ActionUI/ActionUI.Plugin/Patches/SplitScreenManagerPatches.cs
@@ -18,6 +18,9 @@ namespace ModifAmorphic.Outward.ActionUI.Patches
         {
             try
             {
+                if (_player?.AssignedCharacter == null || _player.AssignedCharacter.OwnerPlayerSys == null || !_player.AssignedCharacter.IsLocalPlayer)
+                    return;
+
                 if (__instance.enabled)
                 {
                     Logger.LogTrace($"{nameof(SplitScreenManagerPatches)}::{nameof(RemoveLocalPlayerPostfix)}(): Invoked. Invoking {nameof(RemoveLocalPlayerAfter)}({nameof(SplitScreenManager)}, {nameof(SplitPlayer)}, string).");

--- a/ActionUI/ActionUI.Plugin/Services/CharacterServices/CharacterMenuStashService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/CharacterServices/CharacterMenuStashService.cs
@@ -18,7 +18,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
         Equipment,
         Merchant
     }
-    internal class EquipmentMenuStashService : IDisposable
+    internal class CharacterMenuStashService : IDisposable
     {
         
         private IModifLogger Logger => _getLogger.Invoke();
@@ -51,7 +51,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
 
         private bool disposedValue;
 
-        public EquipmentMenuStashService(Character character, ProfileManager profileManager, InventoryService inventoryService, LevelCoroutines coroutines, Func<IModifLogger> getLogger)
+        public CharacterMenuStashService(Character character, ProfileManager profileManager, InventoryService inventoryService, LevelCoroutines coroutines, Func<IModifLogger> getLogger)
         {
             _character = character;
             _profileManager = profileManager;
@@ -115,29 +115,29 @@ namespace ModifAmorphic.Outward.ActionUI.Services
 
             if (stashType == StashDisplayTypes.Disabled)
             {
-                Logger.LogTrace($"{nameof(EquipmentMenuStashService)}::{nameof(ShouldInvoke)}: false. Stash Type is {stashType} for InventoryContentDisplay '{inventoryPath}'.");
+                Logger.LogTrace($"{nameof(CharacterMenuStashService)}::{nameof(ShouldInvoke)}: false. Stash Type is {stashType} for InventoryContentDisplay '{inventoryPath}'.");
                 return false;
             }
             
             if (inventoryContentDisplay.LocalCharacter.UID != _character.UID)
             {
-                Logger.LogTrace($"{nameof(EquipmentMenuStashService)}::{nameof(ShouldInvoke)}: false. inventoryContentDisplay.LocalCharacter.UID '{inventoryContentDisplay.LocalCharacter.UID}' does not" +
+                Logger.LogTrace($"{nameof(CharacterMenuStashService)}::{nameof(ShouldInvoke)}: false. inventoryContentDisplay.LocalCharacter.UID '{inventoryContentDisplay.LocalCharacter.UID}' does not" +
                     $"equal character.UID '{_character.UID}' for InventoryContentDisplay {inventoryContentDisplay.name}, path: '{inventoryPath}'.");
                 return false;
             }
             if ((stashType == StashDisplayTypes.Inventory || stashType == StashDisplayTypes.Equipment) && _inventoryService.GetStashInventoryEnabled())
             {
-                Logger.LogTrace($"{nameof(EquipmentMenuStashService)}::{nameof(ShouldInvoke)}: true for Inventory Display '{inventoryPath}'");
+                Logger.LogTrace($"{nameof(CharacterMenuStashService)}::{nameof(ShouldInvoke)}: true for Inventory Display '{inventoryPath}'");
                 return true;
             }
 
             if (stashType == StashDisplayTypes.Merchant & _inventoryService.GetMerchantStashEnabled())
             {
-                Logger.LogTrace($"{nameof(EquipmentMenuStashService)}::{nameof(ShouldInvoke)}: true for Merchant Display '{inventoryPath}'");
+                Logger.LogTrace($"{nameof(CharacterMenuStashService)}::{nameof(ShouldInvoke)}: true for Merchant Display '{inventoryPath}'");
                 return true;
             }
 
-            Logger.LogTrace($"{nameof(EquipmentMenuStashService)}::{nameof(ShouldInvoke)}: false for InventoryContentDisplay '{inventoryPath}'.");
+            Logger.LogTrace($"{nameof(CharacterMenuStashService)}::{nameof(ShouldInvoke)}: false for InventoryContentDisplay '{inventoryPath}'.");
             return false;
         }
 
@@ -332,12 +332,14 @@ namespace ModifAmorphic.Outward.ActionUI.Services
 
         private bool IsStashOwned(string itemUID)
         {
-            var displayedStash = _stashDisplays.Values.FirstOrDefault(s => s.IsDisplayed);
+            var displayedStash = _stashDisplays.Values.FirstOrDefault(s => s.isActiveAndEnabled);
 
             if (displayedStash == null)
                 return false;
-
-            return _character.Stash.Contains(itemUID);
+            bool isFound = _character.Stash.Contains(itemUID);
+            if (isFound)
+                Logger.LogDebug($"Found item with UID '{itemUID}' in stash.");
+            return isFound;
         }
 
         protected virtual void Dispose(bool disposing)

--- a/ActionUI/ActionUI.Plugin/Services/CharacterServices/ControllerMapService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/CharacterServices/ControllerMapService.cs
@@ -129,7 +129,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
                 {
                     try
                     {
-                        
+
                         if (outwardMappings.Remove(mapKey))
                         {
                             Logger.LogDebug($"Removed ControllerMap '{mapKey}'.");
@@ -183,7 +183,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
                 GetActionSlotsMap<MouseMap>(forceRefresh)
             );
             if (forceRefresh)
-                _hotbarService.ConfigureHotbars(_hotbarProfileService.GetProfile());
+                _hotbarService.TryConfigureHotbars(_hotbarProfileService.GetProfile());
             return maps;
         }
 
@@ -378,7 +378,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
             }
 
             _hotbarProfileService.Save();
-            _hotbarService.ConfigureHotbars(profile);
+            _hotbarService.TryConfigureHotbars(profile);
         }
 
         private void SetHotbarHotkey(int id, KeyGroup keyGroup, ControllerType controllerType, IEnumerable<ControllerMap> maps)
@@ -393,7 +393,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
             hotbar.HotbarHotkey = hotKey;
 
             _hotbarProfileService.Save();
-            _hotbarService.ConfigureHotbars(profile);
+            _hotbarService.TryConfigureHotbars(profile);
         }
 
         private void SetHotbarNavHotkey(HotkeyCategories category, KeyGroup keyGroup, ControllerType controllerType, IEnumerable<ControllerMap> maps)
@@ -416,7 +416,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
             }
 
             _hotbarProfileService.Save();
-            _hotbarService.ConfigureHotbars(profile);
+            _hotbarService.TryConfigureHotbars(profile);
         }
 
         private void ConfigureButtonMapping(int rewiredActionId, KeyGroup keyGroup, ControllerType controllerType, IEnumerable<ControllerMap> maps, out string hotkeyText)
@@ -625,18 +625,9 @@ namespace ModifAmorphic.Outward.ActionUI.Services
                         _captureDialog.OnKeysSelected -= CaptureDialog_OnKeysSelected;
                 }
 
-                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-                // TODO: set large fields to null
                 disposedValue = true;
             }
         }
-
-        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-        // ~ControllerMapService()
-        // {
-        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-        //     Dispose(disposing: false);
-        // }
 
         public void Dispose()
         {

--- a/ActionUI/ActionUI.Plugin/Services/CharacterServices/EquipService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/CharacterServices/EquipService.cs
@@ -97,8 +97,8 @@ namespace ModifAmorphic.Outward.ActionUI.Services
 
             //Creates ItemDisplays for equipment set skills.
 
-            _character.CharacterUI.ShowMenu(CharacterUI.MenuScreens.Skills);
-            _character.CharacterUI.HideMenu(CharacterUI.MenuScreens.Skills);
+            //_character.CharacterUI.ShowMenu(CharacterUI.MenuScreens.Skills);
+            //_character.CharacterUI.HideMenu(CharacterUI.MenuScreens.Skills);
 
         }
 
@@ -196,7 +196,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
             {
                 AddEquipmentSets<ArmorSetSkill>(_profileManager.ArmorSetService.GetEquipmentSetsProfile().EquipmentSets, true);
                 AddEquipmentSets<WeaponSetSkill>(_profileManager.WeaponSetService.GetEquipmentSetsProfile().EquipmentSets, true);
-                
+
             }
             else
             {
@@ -672,7 +672,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
                     if (_profileManager?.ProfileService != null)
                     {
                         _profileManager.ProfileService.OnActiveProfileChanged -= TryProfileChanged;
-                     
+
                         _profileManager.ProfileService.OnActiveProfileSwitched -= TryProfileSwitched;
                     }
                     ClearSkillPreviewCache();
@@ -682,13 +682,6 @@ namespace ModifAmorphic.Outward.ActionUI.Services
                 disposedValue = true;
             }
         }
-
-        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-        // ~InventoryService()
-        // {
-        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-        //     Dispose(disposing: false);
-        // }
 
         public void Dispose()
         {

--- a/ActionUI/ActionUI.Plugin/Services/CharacterServices/EquipService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/CharacterServices/EquipService.cs
@@ -338,8 +338,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
 
         public bool HasItem(EquipSlot equipSlot) => equipSlot == null
                         || _characterInventory.OwnsItem(equipSlot.UID)
-                        || (_equipSetsProfile.StashEquipEnabled && _inventoryService.GetAreaContainsStash() && _character.Stash.GetContainedItemUIDs(equipSlot.ItemID).Any())
-                        || (_equipSetsProfile.StashEquipEnabled && _equipSetsProfile.StashEquipAnywhereEnabled && _character.Stash.GetContainedItemUIDs(equipSlot.ItemID).Any());
+                        || (GetIsStashEquipEnabled() && _character.Stash.GetContainedItemUIDs(equipSlot.ItemID).Any());
 
         public bool IsArmorSetEquipped(ArmorSet armorSet)
             => IsEquipSlotEquipped(armorSet.Head, EquipmentSlot.EquipmentSlotIDs.Helmet) &&

--- a/ActionUI/ActionUI.Plugin/Services/CharacterServices/InventoryService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/CharacterServices/InventoryService.cs
@@ -208,24 +208,17 @@ namespace ModifAmorphic.Outward.ActionUI.Services
                 if (disposing)
                 {
                     CharacterInventoryPatches.AfterInventoryIngredients -= AddStashIngredients;
-                    //TryRemoveStashPreserver();
                     if (_profileManager?.ProfileService != null)
                     {
                         _profileManager.ProfileService.OnActiveProfileChanged -= TryConfigureStashPreserver;
                         _profileManager.ProfileService.OnActiveProfileSwitched -= TryConfigureStashPreserver;
                     }
+
                 }
                 _character = null;
                 disposedValue = true;
             }
         }
-
-        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-        // ~InventoryService()
-        // {
-        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-        //     Dispose(disposing: false);
-        // }
 
         public void Dispose()
         {

--- a/ActionUI/ActionUI.Plugin/Services/CharacterServices/SlotDataService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/CharacterServices/SlotDataService.cs
@@ -1,5 +1,4 @@
 ﻿using ModifAmorphic.Outward.ActionUI.DataModels;
-using ModifAmorphic.Outward.ActionUI.Extensions;
 using ModifAmorphic.Outward.ActionUI.Models;
 using ModifAmorphic.Outward.Logging;
 using ModifAmorphic.Outward.Unity.ActionUI;

--- a/ActionUI/ActionUI.Plugin/Services/DurabilityDisplayService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/DurabilityDisplayService.cs
@@ -13,7 +13,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
     {
         private readonly Func<IModifLogger> _loggerFactory;
         private IModifLogger Logger => _loggerFactory.Invoke();
-
+        private PlayerMenuService _playerMenuService;
         private bool _unequipedAdded;
 
         private bool _equipTracked = false;
@@ -31,20 +31,33 @@ namespace ModifAmorphic.Outward.ActionUI.Services
             { UnequippedBoots.DurableEquipmentSlot, UnequippedBoots }
         };
 
-        public DurabilityDisplayService(Func<IModifLogger> loggerFactory)
+        public DurabilityDisplayService(PlayerMenuService playerMenuService, Func<IModifLogger> loggerFactory)
         {
-            (_loggerFactory) = (loggerFactory);
+            (_playerMenuService, _loggerFactory) = (playerMenuService, loggerFactory);
 
             EquipmentPatches.AfterOnEquip += TrackEquippedItem;
             EquipmentPatches.AfterOnUnequip += UntrackEquippedItem;
-            SplitPlayerPatches.SetCharacterAfter += ConfigureShowHide;
+            //SplitPlayerPatches.SetCharacterAfter += ConfigureShowHide;
+            _playerMenuService.OnPlayerActionMenusConfigured += TryConfigureShowHide;
             SplitScreenManagerPatches.RemoveLocalPlayerAfter += SplitScreenManagerPatches_RemoveLocalPlayerAfter;
         }
 
-        private void ConfigureShowHide(SplitPlayer splitPlayer, Character character)
+        private void TryConfigureShowHide(PlayerActionMenus actionMenus, SplitPlayer splitPlayer)
         {
-            var psp = Psp.Instance.GetServicesProvider(splitPlayer.RewiredID);
-            var actionMenus = psp.GetService<PlayerActionMenus>();
+            try
+            {
+                ConfigureShowHide(actionMenus, splitPlayer);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("Failed to configure DurabilityDisplayService.", ex);
+            }
+        }
+
+        private void ConfigureShowHide(PlayerActionMenus actionMenus, SplitPlayer splitPlayer)
+        {
+            //var psp = Psp.Instance.GetServicesProvider(splitPlayer.RewiredID);
+            //var actionMenus = psp.GetService<PlayerActionMenus>();
             var profileService = actionMenus.ProfileManager.ProfileService;
 
             Reset(actionMenus);

--- a/ActionUI/ActionUI.Plugin/Services/EquipSetPrefabService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/EquipSetPrefabService.cs
@@ -8,8 +8,6 @@ using ModifAmorphic.Outward.Unity.ActionUI.Models.EquipmentSets;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -23,10 +21,13 @@ namespace ModifAmorphic.Outward.ActionUI.Services
         private readonly InventoryServicesInjector _inventoryServicesInjector;
         private readonly ModifCoroutine _coroutines;
 
+        public static EquipSetPrefabService Instance;
+
         public EquipSetPrefabService(InventoryServicesInjector inventoryServicesInjector, ModifCoroutine coroutines, Func<IModifLogger> getLogger)
         {
             (_inventoryServicesInjector, _coroutines, _getLogger) = (inventoryServicesInjector, coroutines, getLogger);
             _inventoryServicesInjector.EquipmentSetProfilesLoaded += TryAddEquipmentSets;
+            Instance = this;
         }
 
         private void TryAddEquipmentSets(int playerID, string characterUID, ArmorSetsJsonService armorService, WeaponSetsJsonService weaponService)

--- a/ActionUI/ActionUI.Plugin/Services/Injectors/InventoryServicesInjector.cs
+++ b/ActionUI/ActionUI.Plugin/Services/Injectors/InventoryServicesInjector.cs
@@ -80,6 +80,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services.Injectors
 
         private void AddInventoryServices(PlayerActionMenus actionMenus, SplitPlayer splitPlayer)
         {
+            Logger.LogDebug($"Adding Inventory Services for player {splitPlayer.RewiredID}");
 
             var usp = Psp.Instance.GetServicesProvider(splitPlayer.RewiredID);
             var profileManager = usp.GetService<ProfileManager>();
@@ -108,6 +109,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services.Injectors
 
             usp.GetService<InventoryService>().Start();
             usp.GetService<EquipService>().Start();
+            usp.GetService<CharacterMenuStashService>().Start();
         }
     }
 }

--- a/ActionUI/ActionUI.Plugin/Services/Injectors/InventoryServicesInjector.cs
+++ b/ActionUI/ActionUI.Plugin/Services/Injectors/InventoryServicesInjector.cs
@@ -98,7 +98,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services.Injectors
                                                     _services.GetService<EquipSetPrefabService>(),
                                                     _coroutines,
                                                     _getLogger))
-                .AddSingleton(new EquipmentMenuStashService(
+                .AddSingleton(new CharacterMenuStashService(
                     splitPlayer.AssignedCharacter,
                     profileManager,
                     usp.GetService<InventoryService>(),

--- a/ActionUI/ActionUI.Plugin/Services/Json/GlobalProfileService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/Json/GlobalProfileService.cs
@@ -58,8 +58,8 @@ namespace ModifAmorphic.Outward.ActionUI.Services
             return set;
         }
 
-        public int GetNextEquipmentSetID() 
-        { 
+        public int GetNextEquipmentSetID()
+        {
             int nextId = _random.Next(InventorySettings.MinSetItemID, InventorySettings.MaxSetItemID);
             int attempt = 0;
             int maxAttempts = 1000;

--- a/ActionUI/ActionUI.Plugin/Services/Json/ISavableProfile.cs
+++ b/ActionUI/ActionUI.Plugin/Services/Json/ISavableProfile.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ModifAmorphic.Outward.ActionUI.Services
-{ 
+﻿namespace ModifAmorphic.Outward.ActionUI.Services
+{
     internal interface ISavableProfile
     {
         void Save();

--- a/ActionUI/ActionUI.Plugin/Services/Json/ProfileService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/Json/ProfileService.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using UnityEngine.Events;
 
 namespace ModifAmorphic.Outward.ActionUI.Services
 {
@@ -90,7 +89,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
         {
             if (_activeProfile != null && _activeProfile.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
                 return;
-            
+
             Logger.LogInfo($"Setting active profile to profile '{name}'.");
             Logger.LogInfo($"Saving active profile '{_activeProfile.Name}' before changing profiles.");
             Save();
@@ -102,7 +101,6 @@ namespace ModifAmorphic.Outward.ActionUI.Services
 
             var profile = profiles.Profiles.FirstOrDefault(p => p.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
 
-            bool isNewProfile = false;
             if (profile != null)
             {
                 profile.Name = name;
@@ -117,7 +115,6 @@ namespace ModifAmorphic.Outward.ActionUI.Services
                     Path = Path.Combine(ProfilesPath, name),
                 };
                 profiles.Profiles.Add(profile);
-                isNewProfile = true;
             }
 
             profiles.ActiveProfile = name;
@@ -148,7 +145,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
             //Save the current profiles before switching to a new one.
             Save();
             OnActiveProfileSwitching.TryInvoke(GetActiveActionUIProfile());
-            
+
             SaveProfile(profile, false);
             OnActiveProfileSwitched.TryInvoke(profile);
         }
@@ -326,9 +323,9 @@ namespace ModifAmorphic.Outward.ActionUI.Services
         {
             if (!Directory.Exists(ProfilesPath))
                 Directory.CreateDirectory(ProfilesPath);
-            
+
             Logger.LogInfo($"Saving Action UI Profile to '{ProfilesFile}'.");
-            
+
             var newJson = JsonConvert.SerializeObject(profiles, Formatting.Indented);
             File.WriteAllText(ProfilesFile, newJson);
             _activeProfile = null;

--- a/ActionUI/ActionUI.Plugin/Services/Json/WeaponSetsJsonService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/Json/WeaponSetsJsonService.cs
@@ -84,7 +84,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
         public bool IsSetEquipped(WeaponSet weaponSet) => _equipService.IsWeaponSetEquipped(weaponSet);
 
         public bool IsContainedInSet(string itemUID) =>
-            GetEquipmentSetsProfile().EquipmentSets.Any(set => set.GetEquipSlots().Any(slot => slot.UID == itemUID));
+            GetEquipmentSetsProfile().EquipmentSets.Any(set => set.GetEquipSlots().Any(slot => slot != null && slot.UID == itemUID));
 
         public WeaponSet GetEquippedAsSet(string name)
         {

--- a/ActionUI/ActionUI.Plugin/Services/PositionsService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/PositionsService.cs
@@ -4,7 +4,6 @@ using ModifAmorphic.Outward.Extensions;
 using ModifAmorphic.Outward.GameObjectResources;
 using ModifAmorphic.Outward.Logging;
 using ModifAmorphic.Outward.Unity.ActionMenus;
-using ModifAmorphic.Outward.Unity.ActionUI.Data;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -112,12 +111,18 @@ namespace ModifAmorphic.Outward.ActionUI.Services
             if (_isKeepPositionablesListening)
                 return;
 
-            var uiPositionScreen = actionMenus.GetComponentInChildren<UIPositionScreen>();
-            var hud = characterUI.transform.Find("Canvas/GameplayPanels/HUD");
-            var positonables = hud.GetComponentsInChildren<PositionableUI>(true).Where(p => p != null);
-            uiPositionScreen.OnShow.AddListener(() => _coroutine.StartRoutine(KeepPositionablesVisible(positonables.ToArray())));
-
-            _isKeepPositionablesListening = true;
+            try
+            {
+                var uiPositionScreen = actionMenus.GetComponentInChildren<UIPositionScreen>(true);
+                var hud = characterUI.transform.Find("Canvas/GameplayPanels/HUD");
+                var positonables = hud.GetComponentsInChildren<PositionableUI>(true).Where(p => p != null);
+                uiPositionScreen.OnShow.AddListener(() => _coroutine.StartRoutine(KeepPositionablesVisible(positonables.ToArray())));
+                _isKeepPositionablesListening = true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("Failed to start Keep Postionables Visible coroutine", ex);
+            }
         }
 
         private IEnumerator KeepPositionablesVisible(PositionableUI[] positionables)

--- a/ActionUI/ActionUI.Plugin/Services/ResetActionUIsService.cs
+++ b/ActionUI/ActionUI.Plugin/Services/ResetActionUIsService.cs
@@ -134,7 +134,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
 
             Psp.Instance.TryDisposeServicesProvider(rewiredId);
             CharacterUIPatches.GetIsMenuFocused.TryRemove(rewiredId, out _);
-            
+
             try
             {
                 characterUI.GetComponentInChildren<EquipmentSetMenu>(true).gameObject.Destroy();
@@ -143,7 +143,7 @@ namespace ModifAmorphic.Outward.ActionUI.Services
             {
                 Logger.LogException($"Dispose of {nameof(EquipmentSetMenu)} gameobject failed.", ex);
             }
-            
+
             try
             {
                 characterUI.GetComponentInChildren<PlayerActionMenus>(true).gameObject.Destroy();

--- a/ActionUI/ActionUI.Plugin/Settings/ActionUISettings.cs
+++ b/ActionUI/ActionUI.Plugin/Settings/ActionUISettings.cs
@@ -22,7 +22,7 @@ namespace ModifAmorphic.Outward.ActionUI.Settings
 
         public static ActionUIProfile DefaultProfile = new ActionUIProfile()
         {
-            Name = "Profile 1",
+            Name = "Default",
             ActionSlotsEnabled = true,
             DurabilityDisplayEnabled = true,
             EquipmentSetsEnabled = true,

--- a/ActionUI/ActionUI.Plugin/Startup.cs
+++ b/ActionUI/ActionUI.Plugin/Startup.cs
@@ -9,7 +9,6 @@ using ModifAmorphic.Outward.Coroutines;
 using ModifAmorphic.Outward.Extensions;
 using ModifAmorphic.Outward.GameObjectResources;
 using ModifAmorphic.Outward.Logging;
-using ModifAmorphic.Outward.Modules;
 using ModifAmorphic.Outward.Unity.ActionMenus;
 using ModifAmorphic.Outward.Unity.ActionUI;
 using System;

--- a/ActionUI/ActionUI/Controllers/ActionSlotController.cs
+++ b/ActionUI/ActionUI/Controllers/ActionSlotController.cs
@@ -116,7 +116,15 @@ namespace ModifAmorphic.Outward.Unity.ActionUI.Controllers
 
             StartEnableToggleService(slotAction.GetEnabled);
 
-            slotAction.SlotActionAssigned(ActionSlot);
+            try
+            {
+                slotAction.SlotActionAssigned(ActionSlot);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Call to SlotActionAssigned failed for Slot Action '{slotAction.DisplayName}'.");
+                Debug.LogException(ex);
+            }
 
             if (!surpressChangeFlag)
                 ActionSlot.HotbarsContainer.HasChanges = true;

--- a/ActionUI/ActionUI/Data/IActionUIProfileService.cs
+++ b/ActionUI/ActionUI/Data/IActionUIProfileService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using UnityEngine.Events;
 
 namespace ModifAmorphic.Outward.Unity.ActionUI.Data
 {

--- a/ActionUI/ActionUI/Extensions/ToggleExtensions.cs
+++ b/ActionUI/ActionUI/Extensions/ToggleExtensions.cs
@@ -1,6 +1,4 @@
-﻿using UnityEngine.UI;
-
-namespace ModifAmorphic.Outward.Unity.ActionUI.Extensions
+﻿namespace ModifAmorphic.Outward.Unity.ActionUI.Extensions
 {
     public static class ToggleExtensions
     {

--- a/ActionUI/ActionUI/MonoBehaviours/Psp.cs
+++ b/ActionUI/ActionUI/MonoBehaviours/Psp.cs
@@ -31,7 +31,7 @@ namespace ModifAmorphic.Outward.Unity.ActionMenus
                 {
                     disposing.Dispose();
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     Debug.LogError($"ActionUI: Dispose of {nameof(UnityServicesProvider)} for playerID {playerId} failed.");
                     Debug.LogException(ex);

--- a/ActionUI/ActionUI/MonoBehaviours/SettingViews/SettingsView.cs
+++ b/ActionUI/ActionUI/MonoBehaviours/SettingViews/SettingsView.cs
@@ -138,9 +138,13 @@ namespace ModifAmorphic.Outward.Unity.ActionMenus
 
         private void SetProfiles()
         {
+            const string defaultName = "Default";
             ProfileDropdown.ClearOptions();
             var profiles = MainSettingsMenu.PlayerMenu.ProfileManager.ProfileService.GetProfileNames();
-            var profileOptions = profiles.OrderBy(p => p).Select(p => new Dropdown.OptionData(p)).ToList();
+            var profileOptions = profiles.Where(p => !p.Equals(defaultName, StringComparison.InvariantCultureIgnoreCase)).OrderBy(p => p).Select(p => new Dropdown.OptionData(p)).ToList();
+            if (profiles.Any(p => p.Equals("Default", StringComparison.InvariantCultureIgnoreCase)))
+                profileOptions.Insert(0, new Dropdown.OptionData(defaultName));
+
             profileOptions.Add(new Dropdown.OptionData("[New Profile]"));
             ProfileDropdown.AddOptionSilent(profileOptions);
             ProfileDropdown.SetValue(profileOptions.FindIndex(o => o.text.Equals(_profile.Name, StringComparison.InvariantCultureIgnoreCase)));

--- a/ActionUI/ActionUI/MonoBehaviours/SettingViews/StashSettingsView.cs
+++ b/ActionUI/ActionUI/MonoBehaviours/SettingViews/StashSettingsView.cs
@@ -1,7 +1,5 @@
 using ModifAmorphic.Outward.Unity.ActionUI;
 using ModifAmorphic.Outward.Unity.ActionUI.Data;
-using ModifAmorphic.Outward.Unity.ActionUI.Extensions;
-using System;
 using System.Collections;
 using System.Linq;
 using UnityEngine;

--- a/ActionUI/README.md
+++ b/ActionUI/README.md
@@ -64,7 +64,7 @@
   - Equipment Sets equip from stash fix. Set items could be equipped from stash even with the option disabled if the character or merchant stash options where enabled.
   - Action UI settings menu should now open correctly after a split screen session.
   - Fixed bug where user would be prompted to move items from stash to the stash when using the Stash Chest.
-  - Fixed bug that caused weapon set to be unusable if a 2h item was saved in 1h mode using the Mixed Grip mod.
+  - Fixed issue where a 2h weapon set would be unusable if the set was saved in 1h mode using the Mixed Grip mod.
 
 ## Release 1.1.1
   - Fix for Action Slot hotkeys not saving across play sessions.

--- a/ActionUI/README.md
+++ b/ActionUI/README.md
@@ -64,6 +64,7 @@
   - Equipment Sets equip from stash fix. Set items could be equipped from stash even with the option disabled if the character or merchant stash options where enabled.
   - Action UI settings menu should now open correctly after a split screen session.
   - Fixed bug where user would be prompted to move items from stash to the stash when using the Stash Chest.
+  - Fixed bug that caused weapon set to be unusable if a 2h item was saved in 1h mode using the Mixed Grip mod.
 
 ## Release 1.1.1
   - Fix for Action Slot hotkeys not saving across play sessions.

--- a/ActionUI/README.md
+++ b/ActionUI/README.md
@@ -60,9 +60,16 @@
 ***
 
 ## Latest Release ${PACKAGE_VERSION}
+  - Characters should no longer be stuck in a T-pose when joining another game.
+  - Equipment Sets equip from stash fix. Set items could be equipped from stash even with the option disabled if the character or merchant stash options where enabled.
+  - Action UI settings menu should now open correctly after a split screen session.
+  - Fixed bug where user would be prompted to move items from stash to the stash when using the Stash Chest.
+
+## Release 1.1.1
   - Fix for Action Slot hotkeys not saving across play sessions.
     - Technically, they were saving but Outward was overriding them with an older copy on load. Fix ensures Outward no longer stores it's own copy in the "Player{0}_Keymappings.xml" file. Existing older mappings should automatically be removed on the next game exit.
   - Corrected display issue with Hotkey Capture. Capture text was displaying "Backspace" and "Tab" when keys "8" or "9" were pressed.
+
 ## Release 1.1.0
   - Added new Stash settings menu that enables the stash in several character menus. In town only by default.
     - Added stash to the bottom of the inventory menu.


### PR DESCRIPTION
- Characters should no longer be stuck in a T-pose when joining another game.
- Equipment Sets equip from stash fix. Set items could be equipped from stash even with the option disabled if the character or merchant stash options where enabled.
- Action UI settings menu should now open correctly after a split screen session.
- Fixed bug where user would be prompted to move items from stash to the stash when using the Stash Chest.
- Fixed issue where a 2h weapon set would be unusable if the set was saved in 1h mode using the Mixed Grip mod.