### PR TITLE
Fix for invalid filename chars. Warning for duplicate schools

### DIFF
--- a/RespecPotions/README.md
+++ b/RespecPotions/README.md
@@ -18,6 +18,11 @@ Adds Blackout Potions to each town's local alchemist stock. For existing saves, 
 # Change Logs
 
 ## Latest Release ${PACKAGE_VERSION}
+- Fix for custom classes with non alpha characters in their names.
+  - Certain characters would cause the mod to fail to create and add potions to merchant inventories.
+- Added warning to duplicate potion descriptions for when a custom class mod registers the same skill school name multiple times.
+
+## Latest Release 1.0.1
 - Updated for Definitive Edition.
 - Removed Health Loss on consuming a potion. Was buggy when forgetting skills that added to health.
 

--- a/RespecPotions/README.md
+++ b/RespecPotions/README.md
@@ -22,7 +22,7 @@ Adds Blackout Potions to each town's local alchemist stock. For existing saves, 
   - Certain characters would cause the mod to fail to create and add potions to merchant inventories.
 - Added warning to duplicate potion descriptions for when a custom class mod registers the same skill school name multiple times.
 
-## Latest Release 1.0.1
+## Release 1.0.1
 - Updated for Definitive Edition.
 - Removed Health Loss on consuming a potion. Was buggy when forgetting skills that added to health.
 

--- a/RespecPotions/RespecPotions/ModifAmorphic.Outward.RespecPotions.csproj
+++ b/RespecPotions/RespecPotions/ModifAmorphic.Outward.RespecPotions.csproj
@@ -5,9 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModifAmorphic.Outward" Version="0.5.7" />
+    <PackageReference Include="ModifAmorphic.Outward" Version="0.5.18" />
   </ItemGroup>
-
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath>..\..\outward-shared-assemblies\0Harmony.dll</HintPath>

--- a/RespecPotions/RespecPotions/PotionItemService.cs
+++ b/RespecPotions/RespecPotions/PotionItemService.cs
@@ -14,6 +14,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace ModifAmorphic.Outward.RespecPotions
 {
@@ -99,38 +100,39 @@ namespace ModifAmorphic.Outward.RespecPotions
                 characterInstances.TryGetSkillSchools(out var skillSchools);
 
                 var prefabItems = new List<Item>();
-
+                //var prefabItems = new Dictionary<string, Item>();
                 var basePrefab = _resourcesPrefabManager.GetItemPrefab(4300220);
 
                 foreach (int schoolIndex in skillSchools.Keys)
                 {
+                    //if (prefabItems.TryGetValue(skillSchools[schoolIndex].name, out var existingPotion))
+                    //{
+                    //    _ = TryAddForgetSchoolEffect(existingPotion, schoolIndex);
+                    //    Logger.LogTrace($"{nameof(PotionItemService)}::{nameof(AddForgetPotionPrefabs)}: Added additional effect {nameof(ForgetSchoolEffect)} with SchoolIndex of {schoolIndex} to existing prefab {existingPotion.name}.");
+                    //}
+                    //else if (TryGetForgetPotion(skillSchools[schoolIndex], schoolIndex, basePrefab, iconDir, out var potionPrefab))
+                    //{
+                    //    Logger.LogTrace($"{nameof(PotionItemService)}::{nameof(AddForgetPotionPrefabs)}: Added effect {nameof(ForgetSchoolEffect)} with SchoolIndex of {schoolIndex} to prefab {potionPrefab.name}.");
+
+                    //    prefabItems.Add(skillSchools[schoolIndex].name, potionPrefab);
+                    //}
                     var potionName = RespecConstants.PotionNameFormat.Replace("{SchoolName}", skillSchools[schoolIndex].Name);
                     var potionDesc = RespecConstants.PotionDescFormat.Replace("{SchoolName}", skillSchools[schoolIndex].Name);
 
-                    var potionPrefab = _preFabricator.CreatePrefab(basePrefab, RespecConstants.ItemStartID - schoolIndex, potionName, potionDesc);
-                    Logger.LogTrace($"{nameof(PotionItemService)}::{nameof(AddForgetPotionPrefabs)}: potionPrefab.gameObject.activeSelf={potionPrefab.gameObject.activeSelf}.");
-                    //potionPrefab.gameObject.SetActive(true);
-
-                    var iconFileName = GetIconFilePath(skillSchools[schoolIndex].name, iconDir);
-
-                    Logger.LogDebug($"{nameof(PotionItemService)}::{nameof(AddForgetPotionPrefabs)}: Created '{potionPrefab.Name}' prefab with ItemID {potionPrefab.ItemID}.");
-                    potionPrefab.ClearEffects()
-                        .ConfigureItemIcon(Path.Combine(iconDir, iconFileName))
-                        .AddEffect<ForgetSchoolEffect>()
-                        .SchoolIndex = schoolIndex;
-                    potionPrefab.AddEffect<AutoKnock>();
-                    //potionPrefab.AddEffect<BurnHealthEffect>()
-                    //    .AffectQuantity = .25f;
-                    potionPrefab.AddEffect<BurnStaminaEffect>()
-                        .AffectQuantity = .25f;
-
-                    var itemStats = potionPrefab.gameObject.GetOrAddComponent<ItemStats>();
-                    itemStats.SetBaseValue(_settings.PotionValue.Value);
-
-                    Logger.LogTrace($"{nameof(PotionItemService)}::{nameof(AddForgetPotionPrefabs)}: Added effect {nameof(ForgetSchoolEffect)} with SchoolIndex of {schoolIndex} to prefab {potionPrefab.ItemID}.");
-
-                    prefabItems.Add(potionPrefab);
+                    if (prefabItems.Any(p => p.Name.Equals(potionName, StringComparison.InvariantCultureIgnoreCase)))
+                    {
+                        potionName += $" [{schoolIndex}]";
+                        potionDesc = RespecConstants.PotionDescFormat.Replace("{SchoolName}", potionName);
+                        potionDesc += "\n" + RespecConstants.PotionDuplicateFormat.Replace("{SchoolName}", skillSchools[schoolIndex].Name);
+                        Logger.LogDebug($"{nameof(PotionItemService)}::{nameof(AddForgetPotionPrefabs)}: Found duplicate potion with Name {skillSchools[schoolIndex].Name}. Renamed new potion to {potionName}.");
+                    }
+                    if (TryGetForgetPotion(skillSchools[schoolIndex], schoolIndex, potionName, potionDesc, basePrefab, iconDir, out var potionPrefab))
+                    {
+                        prefabItems.Add(potionPrefab);
+                        Logger.LogTrace($"{nameof(PotionItemService)}::{nameof(AddForgetPotionPrefabs)}: Added effect {nameof(ForgetSchoolEffect)} with SchoolIndex of {schoolIndex} to prefab {potionPrefab.name}.");
+                    }
                 }
+
                 Logger.LogInfo($"Created Respec Potions for {skillSchools.Count} schools.");
                 PotionPrefabsAdded?.Invoke(prefabItems);
             }
@@ -140,14 +142,96 @@ namespace ModifAmorphic.Outward.RespecPotions
                 coroutineStarted = false;
             }
         }
+
+        private bool TryGetForgetPotion(SkillSchool skillSchool, int schoolIndex, string potionName, string potionDesc, Item basePortionPrefab, string iconDir, out Item forgetPotion)
+        {
+            try
+            {
+                forgetPotion = _preFabricator.CreatePrefab(basePortionPrefab, RespecConstants.ItemStartID - schoolIndex, potionName, potionDesc, true);
+                Logger.LogTrace($"{nameof(PotionItemService)}::{nameof(AddForgetPotionPrefabs)}: potionPrefab.gameObject.activeSelf={forgetPotion.gameObject.activeSelf}.");
+                //potionPrefab.gameObject.SetActive(true);
+
+                var iconFileName = GetIconFilePath(skillSchool.name, iconDir);
+
+                Logger.LogDebug($"{nameof(PotionItemService)}::{nameof(AddForgetPotionPrefabs)}: Created '{forgetPotion.Name}' prefab with ItemID {forgetPotion.ItemID}.");
+                forgetPotion.ClearEffects()
+                    .ConfigureItemIcon(Path.Combine(iconDir, iconFileName))
+                    .AddEffect<ForgetSchoolEffect>()
+                    .SchoolIndex = schoolIndex;
+                forgetPotion.AddEffect<AutoKnock>();
+                //potionPrefab.AddEffect<BurnHealthEffect>()
+                //    .AffectQuantity = .25f;
+                forgetPotion.AddEffect<BurnStaminaEffect>()
+                    .AffectQuantity = .25f;
+
+                var itemStats = forgetPotion.gameObject.GetOrAddComponent<ItemStats>();
+                itemStats.SetBaseValue(_settings.PotionValue.Value);
+                
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (!string.IsNullOrWhiteSpace(skillSchool?.name))
+                    Logger.LogException($"Failed to create forgot potion for school '{skillSchool.name}'", ex);
+                else
+                    Logger.LogException($"Failed to create forgot potion for school index {schoolIndex}", ex);
+            }
+
+            forgetPotion = null;
+            return false;
+        }
+
+        private bool TryAddForgetSchoolEffect(Item item, int schoolIndex)
+        {
+            try
+            {
+                item
+                    .AddEffect<ForgetSchoolEffect>()
+                    .SchoolIndex = schoolIndex;
+                return true;
+            }
+            catch(Exception ex)
+            {
+                Logger.LogException($"Failed to add {nameof(ForgetSchoolEffect)} to item {item?.name} for school index {schoolIndex}.", ex);
+            }
+
+            return false;
+        }
+
         private string GetIconFilePath(string schoolname, string iconDirectory)
         {
             if (RespecConstants.CustomSchoolIcons.TryGetValue(schoolname, out var iFile) && File.Exists(Path.Combine(iconDirectory, iFile)))
                 return Path.Combine(iconDirectory, iFile);
 
-            string otherIcon = Path.Combine(iconDirectory, schoolname + ".png");
+            try
+            {
+                var cleanFile = RemoveInvalidFilePathCharacters(schoolname + ".png", "_");
+                var filePath = Path.Combine(iconDirectory, cleanFile);
+                Logger.LogDebug($"Original Filename: '{schoolname + ".png"}'. Cleaned Filename: '{cleanFile}'.");
+                if (File.Exists(filePath))
+                    return filePath;
+            }
+            catch
+            {
+                Logger.LogWarning($"Encountered error trying to find school icon file for school {schoolname}. Return default file icon.");
+            }
             
-            return File.Exists(otherIcon) ? otherIcon : RespecConstants.CustomSchoolIcons["Default"];
+            return RespecConstants.CustomSchoolIcons["Default"];
+        }
+        public static string RemoveInvalidFilePathCharacters(string filename, string replaceChar)
+        {
+            string regexSearch = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars());
+            Regex r = new Regex(string.Format("[{0}]", Regex.Escape(regexSearch)));
+            var replaced1 = r.Replace(filename, replaceChar);
+            string replaced2 = string.Empty;
+            foreach(char c in replaced1)
+            {
+                if ((int)c.GetTypeCode() > 126)
+                    replaced2 += "_";
+                else
+                    replaced2 += c;
+            }
+            return replaced2;
         }
     }
 }

--- a/RespecPotions/RespecPotions/PotionItemService.cs
+++ b/RespecPotions/RespecPotions/PotionItemService.cs
@@ -100,22 +100,10 @@ namespace ModifAmorphic.Outward.RespecPotions
                 characterInstances.TryGetSkillSchools(out var skillSchools);
 
                 var prefabItems = new List<Item>();
-                //var prefabItems = new Dictionary<string, Item>();
                 var basePrefab = _resourcesPrefabManager.GetItemPrefab(4300220);
 
                 foreach (int schoolIndex in skillSchools.Keys)
                 {
-                    //if (prefabItems.TryGetValue(skillSchools[schoolIndex].name, out var existingPotion))
-                    //{
-                    //    _ = TryAddForgetSchoolEffect(existingPotion, schoolIndex);
-                    //    Logger.LogTrace($"{nameof(PotionItemService)}::{nameof(AddForgetPotionPrefabs)}: Added additional effect {nameof(ForgetSchoolEffect)} with SchoolIndex of {schoolIndex} to existing prefab {existingPotion.name}.");
-                    //}
-                    //else if (TryGetForgetPotion(skillSchools[schoolIndex], schoolIndex, basePrefab, iconDir, out var potionPrefab))
-                    //{
-                    //    Logger.LogTrace($"{nameof(PotionItemService)}::{nameof(AddForgetPotionPrefabs)}: Added effect {nameof(ForgetSchoolEffect)} with SchoolIndex of {schoolIndex} to prefab {potionPrefab.name}.");
-
-                    //    prefabItems.Add(skillSchools[schoolIndex].name, potionPrefab);
-                    //}
                     var potionName = RespecConstants.PotionNameFormat.Replace("{SchoolName}", skillSchools[schoolIndex].Name);
                     var potionDesc = RespecConstants.PotionDescFormat.Replace("{SchoolName}", skillSchools[schoolIndex].Name);
 

--- a/RespecPotions/RespecPotions/Settings/RespecConstants.cs
+++ b/RespecPotions/RespecPotions/Settings/RespecConstants.cs
@@ -26,6 +26,7 @@ namespace ModifAmorphic.Outward.RespecPotions.Settings
         public static string IconPath = Path.Combine("icons", "ForgetPotions");
         public const string PotionNameFormat = "Blackout - {SchoolName}";
         public const string PotionDescFormat = "<b><color=#d3aa30ff>{SchoolName}</color></b>\nA potent concoction known to cause extreme blackouts. Consuming this potion will cause you to forget all of your training for this school.";
+        public const string PotionDuplicateFormat = "<b><color=#ff4500>Custom Class '{SchoolName}' has been added multiple times. It is unlikely the '{SchoolName}' mod author did this intentionally. Drinking this potion may have unintended consequences, such as forgetting skills from other schools.</color></b>";
 
         /// <summary>
         /// Dictionary collection of Icon File Names, indexed by School Name.


### PR DESCRIPTION
- Fix for custom classes with non alpha characters in their names.
  - Certain characters would cause the mod to fail to create and add potions to merchant inventories.
- Added warning to duplicate potion descriptions for when a custom class mod registers the same skill school name multiple times.